### PR TITLE
updated to include pcielink, NICs, nodes

### DIFF
--- a/etc/ddict.ttl
+++ b/etc/ddict.ttl
@@ -259,6 +259,15 @@
     logset:aspectOf :server ;
     .
 
+# maybe this should be something else
+:pcieLink
+    a logset:SubjectType ;
+    skos:prefLabel "pcieLink" ;
+    skos:note "interface between a node and a nic " ;
+    logset:aspectOf :network ;
+    logset:aspectOf :server ;
+    .
+
 :computeNode
     a logset:SubjectType ;
     skos:prefLabel "compute node" ;

--- a/examples/cray-dict.ttl
+++ b/examples/cray-dict.ttl
@@ -46,6 +46,9 @@
 :greenLink 
     a ddict:networkLink .
 
+# maybe this should be something else
+:ptileLink 
+    a ddict:networkLink .
 
 # Cray XC systems have a specific service node called the smw (system management
 # workstation) node, which collects many logs

--- a/src/util/archFromInterconnect.pl
+++ b/src/util/archFromInterconnect.pl
@@ -20,7 +20,7 @@ of rtr --interconnect
 
 =over
 
-=item * This is for Cray Gemini and Aries based systems only. Components are inferred from the network connectivity.
+=item * This is for Aries based systems only. Components are inferred from the network connectivity.
 
 =item * We define (for example) C<c0-0c0s0a0n0> to refer to the NIC and it is a child of the router.
 
@@ -33,17 +33,174 @@ of rtr --interconnect
 
 use strict;
 
+my $nnic_aries = 4;
 # from the slots, can infer all, cabs, chassis, nodes, aries. Slot->aries is known
+# use hash, so duplicates are automatically handled, even though this means we have increased storage
 my %HoHcabinet; #for each cab, hash of chassis
 my %HoHchassis; # for each chassis, hash of slots
-my %HoHslot; #infer the nodes and the aries
-my %HoHaries; # for each aries, the rc will have tiles
-my %HoHlink; #for each link --  e1, e2, type. name of the link will be name of the tile
-my %endpoint; #for each endpoint, which it its link?
+my %HoHslot; # infer the nodes and the aries
+# TODO: rename so can handle gemini.
+my %HoHaries; # for each aries, the rc will have tiles and NICs.
+my %HoHlink; # for each link --  e1, e2, type. name of the link will be name of the tile. includes ptile links
+my %HoHPcieLink; # between node and NIC
+my %HoHendpoint; #for each link endpoint, which it its link? nodes, nice, and tiles all go in here
 
 #c0-0c0s0a0l00(0:0:0) green -> c0-0c0s6a0l10(0:0:6)
 #c0-0c0s0a0l01(0:0:0) blue -> unused
 #c0-0c0s0a0l50(0:0:0) ptile -> processor
+
+
+sub addLink{
+    my ($R0,$E0,$R1,$E1,$lname0,$type) = @_;
+    #add this link, otherwise we already have it from the other end
+    $HoHlink{$lname0}{'E0'} = $E0;
+    $HoHlink{$lname0}{'E1'} = $E1;
+    $HoHlink{$lname0}{'R0'} = $R0;
+    $HoHlink{$lname0}{'R1'} = $R1;
+    $HoHlink{$lname0}{'type'} = $type;
+}
+
+sub addEndpoint{
+    my ($E0,$type,$lname0,$pcie) = @_;
+    $HoHendpoint{$E0}{'type'} = $type;
+    $HoHendpoint{$E0}{'link'} = $lname0;
+    $HoHendpoint{$E0}{'pcielink'} = $pcie;
+}
+
+sub printEndpoint{
+    foreach (sort { $b <=> $a } keys(%HoHendpoint) ){
+	my $ep = $_;
+
+	if ($HoHendpoint{$ep}{'type'} =~ /TLE/){
+	    print ":$ep a cray-dict:ariesRouterTile";
+	} elsif ($HoHendpoint{$ep}{'type'} =~ /NIC/){
+	    print ":$ep a ddict:nic";
+	} elsif ($HoHendpoint{$ep}{'type'} =~ /NDE/){
+	    print ":$ep a ddict:computeNode";
+	}
+
+	if (!($HoHendpoint{$ep}{'link'} =~ /N\/A/)){
+	    print "\n\tlogset:endPointOf :" . $HoHendpoint{$ep}{'link'} . ";";
+	}
+	if (!($HoHendpoint{$ep}{'pcielink'} =~ /N\/A/)){
+	    print "\n\tlogset:endPointOf :" . $HoHendpoint{$ep}{'pcielink'} . ";";
+	}
+	print "\t.\n";
+    }    
+    print "\n";
+
+}
+
+sub addAriesTile{
+    my ($R0,$E0) = @_;
+    $HoHaries{$R0}{$E0} = "TLE"; #child of the aries
+}
+
+sub addAriesNIC{
+    my ($R0,$NIC,$nodenum,$lname0) = @_;
+    #adding the NIC, adds the node, and the pcielink
+
+    $HoHaries{$R0}{$NIC} = "NIC"; #child of the aries
+    #add the node
+    if ($R0 =~ /(.*)a0/){
+	my $base = $1;
+	my $node = $base . "n". $nodenum;
+	my $pcie = "pcie" . $node;
+	#node is an enpoint
+	$HoHPcieLink{$pcie} = 1;
+	my @endarr = ();
+	addEndpoint($node,"NDE","N/A",$pcie); #endpoint of the pcie
+	addEndpoint($NIC,"NIC",$lname0,$pcie); #endpoint of the pcie and the ptile link
+    }
+}
+
+sub printCabinet{
+    foreach (sort { $b <=> $a } keys(%HoHcabinet) ){
+	my $cab = $_;
+    
+	print ":$cab a ddict:cabinet\n";
+	foreach (sort { $b <=> $a } keys %{ $HoHcabinet{$cab} } ){
+	    my $chassis = $_;
+	    print "\tlogset:hasPart :$chassis;\n";
+	}
+	print "\t.\n";
+	print "\n";
+    }
+}
+
+
+sub printChassis{
+    foreach (sort { $b <=> $a } keys(%HoHchassis) ){
+	my $chassis = $_;
+    
+	print ":$chassis a ddict:chassis\n";
+	foreach (sort { $b <=> $a } keys %{ $HoHchassis{$chassis} } ){
+	    my $slot = $_;
+	    print "\tlogset:hasPart :$slot;\n";
+	}
+	print "\t.\n";
+	print "\n";
+    }
+}
+
+sub printSlot{
+    foreach (sort { $b <=> $a } keys(%HoHslot) ){
+	my $slot = $_;
+	print ":$slot a ddict:blade\n";
+
+	#well known slots have nodes
+	for (my $i = 0; $i < 4; $i++){
+	    print "\tlogset:hasPart :$slot" . "n$i;\n";
+	}
+
+	#well known slots have aries
+	print "\tlogset:hasPart :$slot" . "a0;\n";
+	print "\t.\n";
+	print "\n";
+    }
+}
+
+
+sub printAries{
+    #aries will have both tile and NIC children. they will be added as endpoints
+
+    foreach (sort { $b <=> $a } keys(%HoHaries) ){
+	my $aries = $_;
+	print ":$aries a cray-dict:ariesRouter\n";
+	foreach (sort { $b <=> $a } keys %{ $HoHaries{$aries} } ){
+	    my $child = $_; # children are both TILES and NICS. Here we do not care which type
+	    print "\tlogset:hasPart :$child;\n";
+	}
+	print "\t.\n";
+	print "\n";
+    }
+}
+
+sub printPcieLink{
+    foreach (sort { $b <=> $a } keys(%HoHPcieLink) ){
+	my $link = $_;
+	print ":$link a ddict:pcieLink .\n";
+    }
+    print "\n";
+}
+    
+
+sub printLink{
+    foreach (sort { $b <=> $a } keys(%HoHlink) ){
+	my $link = $_;
+
+	if ($HoHlink{$link}{'type'} =~ /BLU/){
+	    print ":$link a cray-dict:blueLink .\n";
+	} elsif ($HoHlink{$link}{'type'} =~ /GRE/){
+	    print ":$link a cray-dict:greenLink .\n";
+	} elsif ($HoHlink{$link}{'type'} =~ /BLK/){
+	    print ":$link a cray-dict:blackLink .\n";
+	} elsif ($HoHlink{$link}{'type'} =~ /PTL/){
+	    print ":$link a cray-dict:ptileLink .\n";
+	}
+    }
+    print "\n";
+}
 
 while(<>){
     chomp;
@@ -60,28 +217,9 @@ while(<>){
 	my $R0 = -1;
 	my $R1 = -1;
 
-	if (($vals[0] =~ /(.*)\[/) || ($vals[0] =~ /(.*\d)\(/)){
-	    $E0 = $1;
-	    if ($E0 =~ /(.*)l/){
-		$R0 = $1;
-		$HoHaries{$R0}{$E0} = 1;
-	    }
-	}
-
+	#what type of connection is this?
 	my $type = -1;
-	if ($vals[1] eq 'X+'){
-	    $type = "XP0";
-	} elsif ($vals[1] eq 'X_'){
-	    $type = "XM0";
-	} elsif ($vals[1] eq 'Y+'){
-	    $type = "YP0";
-	} elsif ($vals[1] eq 'Y_'){
-	    $type = "YM0";
-	} elsif ($vals[1] eq 'Z+'){
-	    $type = "ZP0";
-	} elsif ($vals[1] eq 'Z_'){
-	    $type = "ZM0";
-	} elsif ($vals[1] eq 'blue'){
+	if ($vals[1] eq 'blue'){
 	    $type = "BLU";
 	} elsif ($vals[1] eq 'black'){
 	    $type = "BLK";
@@ -89,51 +227,71 @@ while(<>){
 	    $type = "GRE";
 	} elsif ($vals[1] eq 'ptile'){
 	    $type = "PTL";
-	} elsif ($vals[1] eq 'host'){
+	} elsif ($vals[1] eq 'host'){ # DNE
 	    $type = "HST";
 	} else {
 	    $type = "UNK";
 	}
 
+	#first entry should always be a valid tile
+	if (($vals[0] =~ /(.*)\[/) || ($vals[0] =~ /(.*\d)\(/)){
+	    $E0 = $1;
+	    if ($E0 =~ /(.*)l/){
+		$R0 = $1;
+		addAriesTile($R0,$E0);
+	    }
+	}
+
 	if (($vals[3] =~ /(.*)\[/) || ($vals[3] =~ /(.*\d)\(/)){
+	    # this is a 2-ended link
 	    $E1 = $1;
 	    if ($E1 =~ /(.*)l/){
 		$R1 = $1;
-#		$HoHaries{$R1}{$E1} = 1; dont need this since will pick it up on the other side
+		#dont add the aries for this side; will pick it up on the other side of the link
 	    }
 
 	    # these will readin as double, one for each endpoint, so check to see if we already have this one
 	    my $lname0 = "link" . $E0;
 	    my $lname1 = "link" . $E1;
 	    if (!(exists $HoHlink{$lname0}) && !(exists $HoHlink{$lname1})){
-		#add this link, otherwise we already have the other end
-		$HoHlink{$lname0}{'E0'} = $E0;
-		$HoHlink{$lname0}{'E1'} = $E1;
-		$HoHlink{$lname0}{'R0'} = $R0;
-		$HoHlink{$lname0}{'R1'} = $R1;
-		$HoHlink{$lname0}{'type'} = $type;
-		$endpoint{$E0} = $lname0;
-		$endpoint{$E1} = $lname0;
+		#add this link, otherwise we already have it from the other end
+		addEndpoint($E0,"TLE",$lname0,"N/A");
+		addEndpoint($E1,"TLE",$lname0,"N/A");
+		addLink($R0,$E0,$R1,$E1,$lname0,$type);
 	    }
 	} elsif ($vals[3] =~ /unused/){
-	    #type is still correct for this tile
-	    $E1 = 'unused';
-	    $R1 = 'unused';
+	    #$E1 = "unused"; does not matter
+	    #$R1 = "unused"; does not matter
+	    #add the tile, but not the link
+	    addAriesTile($R0,$E0);
+	    addEndpoint($E0,"TLE","N/A","N/A");
 	} elsif ($vals[3] =~ /processor/){
-	    #type is still correct for this tile
-	    $E1 = 'processor';
-	    $R1 = 'processor';
-	    #add this link 
-	    my $lname0 = "link" . $E0;
-	    $HoHlink{$lname0}{'E0'} = $E0;
-	    $HoHlink{$lname0}{'E1'} = $E1;
-	    $HoHlink{$lname0}{'R0'} = $R0;
-	    $HoHlink{$lname0}{'R1'} = $R1;
-	    $HoHlink{$lname0}{'type'} = $type;
-	    $endpoint{$E0} = $lname0;
-	    #TODO...this endpoint is the NIC
-	}
+	    # TODO: Gemini
+	    # This endpoint is a NIC. aries has 4 NIC and 8 ptiles, in order. get the last digit
+	    my $node = -1;
+	    if ($E0 =~ /.*(\d)/){
+		my $lname0 = "link" . $E0;
+		$R1 = $R0;
+		my $lastdigit = $1;
+		if ($lastdigit < 2){
+		    $node = 0;
+		} elsif ($lastdigit < 4){
+		    $node = 1;
+		} elsif ($lastdigit < 6){
+		    $node = 2;
+		} elsif ($lastdigit < 8){
+		    $node = 3;
+		} else {
+		    die "Cannot determine NIC for $E0\n";
+		}
 
+		$E1 = $R0 . "n". $node;
+		addAriesTile($R0,$E0);
+		addEndpoint($E0,"TLE",$lname0,"N/A");
+		addLink($R0,$E0,$R1,$E1,$lname0,$type); #add the ptile link
+		addAriesNIC($R1,$E1,$node,$lname0); #add the NIC, NODE, and pcie link
+	    }
+	}
 
 	# add the cab, chassis, slot if exist
 	if ($R1 =~ /(c\d+_\d+)/){
@@ -149,102 +307,15 @@ while(<>){
 		$HoHslot{$slot} = 1;
 	    }
 	}
-
-#	    #the other direction should be in there in the case of a network link
-#	    #for non-link (e.g., ptile or unused)......
-#	}
-
     }
-}
+} # while
 
-# ALL THE WRITEOUTS ARE HERE
-    
-foreach (sort { $b <=> $a } keys(%HoHcabinet) ){
-    my $cab = $_;
-    
-#    print "$cab is a cabinet with chassis:\n";
-    print ":$cab a ddict:cabinet\n";
-    foreach (sort { $b <=> $a } keys %{ $HoHcabinet{$cab} } ){
-	my $chassis = $_;
-#	print "\t$chassis\n";
-	print "\tlogset:hasPart :$chassis;\n";
-    }
-    print "\t.\n";
-    print "\n";
-}
+printCabinet();
+printChassis();
+printSlot();
+printAries();
+printLink();
+printEndpoint();
+printPcieLink();
 
-
-foreach (sort { $b <=> $a } keys(%HoHchassis) ){
-    my $chassis = $_;
-    
-#    print "$chassis is a chassis with slots:\n";
-    print ":$chassis a ddict:chassis\n";
-    foreach (sort { $b <=> $a } keys %{ $HoHchassis{$chassis} } ){
-	my $slot = $_;
-	print "\tlogset:hasPart :$slot;\n";
-    }
-    print "\t.\n";
-    print "\n";
-}
-
-foreach (sort { $b <=> $a } keys(%HoHslot) ){
-    my $slot = $_;
-#    print "$slot is a slot with well known:\n";
-    print ":$slot a ddict:blade\n";
-    for (my $i = 0; $i < 4; $i++){
-#	print "\t" . $slot . "n$i\n";
-	print "\tlogset:hasPart :$slot" . "n$i;\n";
-    }
-#    print "\t" . $slot . "a0\n";
-    print "\tlogset:hasPart :$slot" . "a0;\n";
-    print "\t.\n";
-    print "\n";
-}
-
-
-foreach (sort { $b <=> $a } keys(%HoHaries) ){
-    my $aries = $_;
-#    print "$aries is a aries with tiles;\n";
-    print ":$aries a cray-dict:ariesRouter\n";
-    foreach (sort { $b <=> $a } keys %{ $HoHaries{$aries} } ){
-	my $tile = $_;
-#	print "\t$tile\n";
-	print "\tlogset:hasPart :$tile;\n";
-    }
-    print "\t.\n";
-    print "\n";
-}
-
-
-
-foreach (sort { $b <=> $a } keys(%HoHlink) ){
-    my $link = $_;
-
-#    print "<$link> is a link with endpoints and type: \n";
-#    print "\t" . $HoHlink{$link}{'E0'} . "\n";
-#    print "\t" . $HoHlink{$link}{'E1'}. "\n";
-#    print "\t" . $HoHlink{$link}{'type'}. "\n";
-    if ($HoHlink{$link}{'type'} =~ /BLU/){
-	print ":$link a cray-dict:blueLink .\n";
-    }
-    if ($HoHlink{$link}{'type'} =~ /GRE/){
-	print ":$link a cray-dict:greenLink .\n";
-    }
-    if ($HoHlink{$link}{'type'} =~ /BLK/){
-	print ":$link a cray-dict:blackLink .\n";
-
-    }
-    #skipping ptiles for now
-}
-print "\n";
-
-foreach (sort { $b <=> $a } keys(%endpoint) ){
-    my $xendpoint = $_;
-#    print "<$endpoint> is an endpoint of link :\n"; 
-    print ":$xendpoint a cray-dict:ariesRouterTile\n";
-#    print "\t" . $endpoint{$endpoint}. "\n";
-    print "\tlogset:endPointOf :" . $endpoint{$xendpoint} . ";\n";
-    print "\t.\n";
-    print "\n";
-}
 


### PR DESCRIPTION
add pcielink as a type between node and NIC. (NIC is endpoint of two things)
add NICs, nodes, pcielinks, ptilelinks as types with pcielinks and ptilelinks to the dictionaries.

nodes may be over listed -- adding nodes for all NICS, but don't know for sure w/o /etc/hosts.
spot checked values.