### PR TITLE
Changes to the types

### DIFF
--- a/examples/cray-dict.ttl
+++ b/examples/cray-dict.ttl
@@ -39,12 +39,29 @@
     rdfs:comment "The high-radix tile-based router used by Cray Aries" ;
     .
 
+# This will be unused
 :AriesRouterTile
     a owl:Class ;
     rdfs:subClassOf ddict:Port ;
     rdfs:label "aries router tile" ;
     skos:altLabel "tile" ;
     rdfs:comment "a single tile in an Aries router" ;
+    .
+
+:NetworkTile
+    a owl:Class ;
+    rdfs:subClassOf ddict:Port ;
+    rdfs:label "aries router network facing tile" ;
+    skos:altLabel "network tile" ;
+    rdfs:comment "a single network facing tile in an Aries router" ;
+    .
+
+:PTile
+    a owl:Class ;
+    rdfs:subClassOf ddict:Port ;
+    rdfs:label "aries router processor facing tile" ;
+    skos:altLabel "ptile" ;
+    rdfs:comment "a single processor facing tile in an Aries router" ;
     .
 
 :BlueLink

--- a/examples/new_mutrino.ttl
+++ b/examples/new_mutrino.ttl
@@ -1,0 +1,13052 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix logset: <http://portal.nersc.gov/project/mpccc/sleak/resilience/datasets/logset#> .
+@prefix ddict: <http://portal.nersc.gov/project/mpccc/sleak/resilience/datasets/ddict#> .
+@prefix craydict: <http://FIXME/where/is/craydict/published#> .
+
+# declare myself and set a prefix:
+@base <http://FIXME/where/will/this/be/published> .
+@prefix : <FIXME-edison-arch#> .
+
+:
+	a adms:Asset ;
+	dct:title "FIXME give this file a title" ;
+	rdfs:label "FIXME short label" ;
+	.
+
+:c0_0 a ddict:Cabinet ;
+	logset:hasPart :c0_0c0;
+	logset:hasPart :c0_0c1;
+	logset:hasPart :c0_0c2;
+	.
+
+:c1_0 a ddict:Cabinet ;
+	logset:hasPart :c1_0c0;
+	logset:hasPart :c1_0c1;
+	.
+
+:c0_0c0 a ddict:Chassis ;
+	logset:hasPart :c0_0c0s0;
+	logset:hasPart :c0_0c0s1;
+	logset:hasPart :c0_0c0s10;
+	logset:hasPart :c0_0c0s11;
+	logset:hasPart :c0_0c0s2;
+	logset:hasPart :c0_0c0s3;
+	logset:hasPart :c0_0c0s4;
+	logset:hasPart :c0_0c0s5;
+	logset:hasPart :c0_0c0s6;
+	logset:hasPart :c0_0c0s7;
+	logset:hasPart :c0_0c0s8;
+	logset:hasPart :c0_0c0s9;
+	.
+
+:c0_0c1 a ddict:Chassis ;
+	logset:hasPart :c0_0c1s0;
+	logset:hasPart :c0_0c1s1;
+	logset:hasPart :c0_0c1s10;
+	logset:hasPart :c0_0c1s11;
+	logset:hasPart :c0_0c1s12;
+	logset:hasPart :c0_0c1s13;
+	logset:hasPart :c0_0c1s14;
+	logset:hasPart :c0_0c1s15;
+	logset:hasPart :c0_0c1s2;
+	logset:hasPart :c0_0c1s3;
+	logset:hasPart :c0_0c1s4;
+	logset:hasPart :c0_0c1s5;
+	logset:hasPart :c0_0c1s6;
+	logset:hasPart :c0_0c1s7;
+	logset:hasPart :c0_0c1s8;
+	logset:hasPart :c0_0c1s9;
+	.
+
+:c0_0c2 a ddict:Chassis ;
+	logset:hasPart :c0_0c2s0;
+	logset:hasPart :c0_0c2s1;
+	logset:hasPart :c0_0c2s10;
+	logset:hasPart :c0_0c2s11;
+	logset:hasPart :c0_0c2s12;
+	logset:hasPart :c0_0c2s2;
+	logset:hasPart :c0_0c2s3;
+	logset:hasPart :c0_0c2s4;
+	logset:hasPart :c0_0c2s8;
+	logset:hasPart :c0_0c2s9;
+	.
+
+:c1_0c0 a ddict:Chassis ;
+	logset:hasPart :c1_0c0s0;
+	logset:hasPart :c1_0c0s1;
+	logset:hasPart :c1_0c0s10;
+	logset:hasPart :c1_0c0s11;
+	logset:hasPart :c1_0c0s12;
+	logset:hasPart :c1_0c0s13;
+	logset:hasPart :c1_0c0s14;
+	logset:hasPart :c1_0c0s15;
+	logset:hasPart :c1_0c0s2;
+	logset:hasPart :c1_0c0s3;
+	logset:hasPart :c1_0c0s4;
+	logset:hasPart :c1_0c0s5;
+	logset:hasPart :c1_0c0s6;
+	logset:hasPart :c1_0c0s7;
+	logset:hasPart :c1_0c0s8;
+	logset:hasPart :c1_0c0s9;
+	.
+
+:c1_0c1 a ddict:Chassis ;
+	logset:hasPart :c1_0c1s0;
+	logset:hasPart :c1_0c1s1;
+	logset:hasPart :c1_0c1s10;
+	logset:hasPart :c1_0c1s11;
+	logset:hasPart :c1_0c1s12;
+	logset:hasPart :c1_0c1s13;
+	logset:hasPart :c1_0c1s2;
+	logset:hasPart :c1_0c1s3;
+	logset:hasPart :c1_0c1s4;
+	logset:hasPart :c1_0c1s5;
+	logset:hasPart :c1_0c1s6;
+	logset:hasPart :c1_0c1s7;
+	logset:hasPart :c1_0c1s8;
+	logset:hasPart :c1_0c1s9;
+	.
+
+:c0_0c0s0 a ddict:Blade ;
+	logset:hasPart :c0_0c0s0n0;
+	logset:hasPart :c0_0c0s0n1;
+	logset:hasPart :c0_0c0s0n2;
+	logset:hasPart :c0_0c0s0n3;
+	logset:hasPart :c0_0c0s0a0;
+	.
+
+:c0_0c0s1 a ddict:Blade ;
+	logset:hasPart :c0_0c0s1n0;
+	logset:hasPart :c0_0c0s1n1;
+	logset:hasPart :c0_0c0s1n2;
+	logset:hasPart :c0_0c0s1n3;
+	logset:hasPart :c0_0c0s1a0;
+	.
+
+:c0_0c0s10 a ddict:Blade ;
+	logset:hasPart :c0_0c0s10n0;
+	logset:hasPart :c0_0c0s10n1;
+	logset:hasPart :c0_0c0s10n2;
+	logset:hasPart :c0_0c0s10n3;
+	logset:hasPart :c0_0c0s10a0;
+	.
+
+:c0_0c0s11 a ddict:Blade ;
+	logset:hasPart :c0_0c0s11n0;
+	logset:hasPart :c0_0c0s11n1;
+	logset:hasPart :c0_0c0s11n2;
+	logset:hasPart :c0_0c0s11n3;
+	logset:hasPart :c0_0c0s11a0;
+	.
+
+:c0_0c0s2 a ddict:Blade ;
+	logset:hasPart :c0_0c0s2n0;
+	logset:hasPart :c0_0c0s2n1;
+	logset:hasPart :c0_0c0s2n2;
+	logset:hasPart :c0_0c0s2n3;
+	logset:hasPart :c0_0c0s2a0;
+	.
+
+:c0_0c0s3 a ddict:Blade ;
+	logset:hasPart :c0_0c0s3n0;
+	logset:hasPart :c0_0c0s3n1;
+	logset:hasPart :c0_0c0s3n2;
+	logset:hasPart :c0_0c0s3n3;
+	logset:hasPart :c0_0c0s3a0;
+	.
+
+:c0_0c0s4 a ddict:Blade ;
+	logset:hasPart :c0_0c0s4n0;
+	logset:hasPart :c0_0c0s4n1;
+	logset:hasPart :c0_0c0s4n2;
+	logset:hasPart :c0_0c0s4n3;
+	logset:hasPart :c0_0c0s4a0;
+	.
+
+:c0_0c0s5 a ddict:Blade ;
+	logset:hasPart :c0_0c0s5n0;
+	logset:hasPart :c0_0c0s5n1;
+	logset:hasPart :c0_0c0s5n2;
+	logset:hasPart :c0_0c0s5n3;
+	logset:hasPart :c0_0c0s5a0;
+	.
+
+:c0_0c0s6 a ddict:Blade ;
+	logset:hasPart :c0_0c0s6n0;
+	logset:hasPart :c0_0c0s6n1;
+	logset:hasPart :c0_0c0s6n2;
+	logset:hasPart :c0_0c0s6n3;
+	logset:hasPart :c0_0c0s6a0;
+	.
+
+:c0_0c0s7 a ddict:Blade ;
+	logset:hasPart :c0_0c0s7n0;
+	logset:hasPart :c0_0c0s7n1;
+	logset:hasPart :c0_0c0s7n2;
+	logset:hasPart :c0_0c0s7n3;
+	logset:hasPart :c0_0c0s7a0;
+	.
+
+:c0_0c0s8 a ddict:Blade ;
+	logset:hasPart :c0_0c0s8n0;
+	logset:hasPart :c0_0c0s8n1;
+	logset:hasPart :c0_0c0s8n2;
+	logset:hasPart :c0_0c0s8n3;
+	logset:hasPart :c0_0c0s8a0;
+	.
+
+:c0_0c0s9 a ddict:Blade ;
+	logset:hasPart :c0_0c0s9n0;
+	logset:hasPart :c0_0c0s9n1;
+	logset:hasPart :c0_0c0s9n2;
+	logset:hasPart :c0_0c0s9n3;
+	logset:hasPart :c0_0c0s9a0;
+	.
+
+:c0_0c1s0 a ddict:Blade ;
+	logset:hasPart :c0_0c1s0n0;
+	logset:hasPart :c0_0c1s0n1;
+	logset:hasPart :c0_0c1s0n2;
+	logset:hasPart :c0_0c1s0n3;
+	logset:hasPart :c0_0c1s0a0;
+	.
+
+:c0_0c1s1 a ddict:Blade ;
+	logset:hasPart :c0_0c1s1n0;
+	logset:hasPart :c0_0c1s1n1;
+	logset:hasPart :c0_0c1s1n2;
+	logset:hasPart :c0_0c1s1n3;
+	logset:hasPart :c0_0c1s1a0;
+	.
+
+:c0_0c1s10 a ddict:Blade ;
+	logset:hasPart :c0_0c1s10n0;
+	logset:hasPart :c0_0c1s10n1;
+	logset:hasPart :c0_0c1s10n2;
+	logset:hasPart :c0_0c1s10n3;
+	logset:hasPart :c0_0c1s10a0;
+	.
+
+:c0_0c1s11 a ddict:Blade ;
+	logset:hasPart :c0_0c1s11n0;
+	logset:hasPart :c0_0c1s11n1;
+	logset:hasPart :c0_0c1s11n2;
+	logset:hasPart :c0_0c1s11n3;
+	logset:hasPart :c0_0c1s11a0;
+	.
+
+:c0_0c1s12 a ddict:Blade ;
+	logset:hasPart :c0_0c1s12n0;
+	logset:hasPart :c0_0c1s12n1;
+	logset:hasPart :c0_0c1s12n2;
+	logset:hasPart :c0_0c1s12n3;
+	logset:hasPart :c0_0c1s12a0;
+	.
+
+:c0_0c1s13 a ddict:Blade ;
+	logset:hasPart :c0_0c1s13n0;
+	logset:hasPart :c0_0c1s13n1;
+	logset:hasPart :c0_0c1s13n2;
+	logset:hasPart :c0_0c1s13n3;
+	logset:hasPart :c0_0c1s13a0;
+	.
+
+:c0_0c1s14 a ddict:Blade ;
+	logset:hasPart :c0_0c1s14n0;
+	logset:hasPart :c0_0c1s14n1;
+	logset:hasPart :c0_0c1s14n2;
+	logset:hasPart :c0_0c1s14n3;
+	logset:hasPart :c0_0c1s14a0;
+	.
+
+:c0_0c1s15 a ddict:Blade ;
+	logset:hasPart :c0_0c1s15n0;
+	logset:hasPart :c0_0c1s15n1;
+	logset:hasPart :c0_0c1s15n2;
+	logset:hasPart :c0_0c1s15n3;
+	logset:hasPart :c0_0c1s15a0;
+	.
+
+:c0_0c1s2 a ddict:Blade ;
+	logset:hasPart :c0_0c1s2n0;
+	logset:hasPart :c0_0c1s2n1;
+	logset:hasPart :c0_0c1s2n2;
+	logset:hasPart :c0_0c1s2n3;
+	logset:hasPart :c0_0c1s2a0;
+	.
+
+:c0_0c1s3 a ddict:Blade ;
+	logset:hasPart :c0_0c1s3n0;
+	logset:hasPart :c0_0c1s3n1;
+	logset:hasPart :c0_0c1s3n2;
+	logset:hasPart :c0_0c1s3n3;
+	logset:hasPart :c0_0c1s3a0;
+	.
+
+:c0_0c1s4 a ddict:Blade ;
+	logset:hasPart :c0_0c1s4n0;
+	logset:hasPart :c0_0c1s4n1;
+	logset:hasPart :c0_0c1s4n2;
+	logset:hasPart :c0_0c1s4n3;
+	logset:hasPart :c0_0c1s4a0;
+	.
+
+:c0_0c1s5 a ddict:Blade ;
+	logset:hasPart :c0_0c1s5n0;
+	logset:hasPart :c0_0c1s5n1;
+	logset:hasPart :c0_0c1s5n2;
+	logset:hasPart :c0_0c1s5n3;
+	logset:hasPart :c0_0c1s5a0;
+	.
+
+:c0_0c1s6 a ddict:Blade ;
+	logset:hasPart :c0_0c1s6n0;
+	logset:hasPart :c0_0c1s6n1;
+	logset:hasPart :c0_0c1s6n2;
+	logset:hasPart :c0_0c1s6n3;
+	logset:hasPart :c0_0c1s6a0;
+	.
+
+:c0_0c1s7 a ddict:Blade ;
+	logset:hasPart :c0_0c1s7n0;
+	logset:hasPart :c0_0c1s7n1;
+	logset:hasPart :c0_0c1s7n2;
+	logset:hasPart :c0_0c1s7n3;
+	logset:hasPart :c0_0c1s7a0;
+	.
+
+:c0_0c1s8 a ddict:Blade ;
+	logset:hasPart :c0_0c1s8n0;
+	logset:hasPart :c0_0c1s8n1;
+	logset:hasPart :c0_0c1s8n2;
+	logset:hasPart :c0_0c1s8n3;
+	logset:hasPart :c0_0c1s8a0;
+	.
+
+:c0_0c1s9 a ddict:Blade ;
+	logset:hasPart :c0_0c1s9n0;
+	logset:hasPart :c0_0c1s9n1;
+	logset:hasPart :c0_0c1s9n2;
+	logset:hasPart :c0_0c1s9n3;
+	logset:hasPart :c0_0c1s9a0;
+	.
+
+:c0_0c2s0 a ddict:Blade ;
+	logset:hasPart :c0_0c2s0n0;
+	logset:hasPart :c0_0c2s0n1;
+	logset:hasPart :c0_0c2s0n2;
+	logset:hasPart :c0_0c2s0n3;
+	logset:hasPart :c0_0c2s0a0;
+	.
+
+:c0_0c2s1 a ddict:Blade ;
+	logset:hasPart :c0_0c2s1n0;
+	logset:hasPart :c0_0c2s1n1;
+	logset:hasPart :c0_0c2s1n2;
+	logset:hasPart :c0_0c2s1n3;
+	logset:hasPart :c0_0c2s1a0;
+	.
+
+:c0_0c2s10 a ddict:Blade ;
+	logset:hasPart :c0_0c2s10n0;
+	logset:hasPart :c0_0c2s10n1;
+	logset:hasPart :c0_0c2s10n2;
+	logset:hasPart :c0_0c2s10n3;
+	logset:hasPart :c0_0c2s10a0;
+	.
+
+:c0_0c2s11 a ddict:Blade ;
+	logset:hasPart :c0_0c2s11n0;
+	logset:hasPart :c0_0c2s11n1;
+	logset:hasPart :c0_0c2s11n2;
+	logset:hasPart :c0_0c2s11n3;
+	logset:hasPart :c0_0c2s11a0;
+	.
+
+:c0_0c2s12 a ddict:Blade ;
+	logset:hasPart :c0_0c2s12n0;
+	logset:hasPart :c0_0c2s12n1;
+	logset:hasPart :c0_0c2s12n2;
+	logset:hasPart :c0_0c2s12n3;
+	logset:hasPart :c0_0c2s12a0;
+	.
+
+:c0_0c2s2 a ddict:Blade ;
+	logset:hasPart :c0_0c2s2n0;
+	logset:hasPart :c0_0c2s2n1;
+	logset:hasPart :c0_0c2s2n2;
+	logset:hasPart :c0_0c2s2n3;
+	logset:hasPart :c0_0c2s2a0;
+	.
+
+:c0_0c2s3 a ddict:Blade ;
+	logset:hasPart :c0_0c2s3n0;
+	logset:hasPart :c0_0c2s3n1;
+	logset:hasPart :c0_0c2s3n2;
+	logset:hasPart :c0_0c2s3n3;
+	logset:hasPart :c0_0c2s3a0;
+	.
+
+:c0_0c2s4 a ddict:Blade ;
+	logset:hasPart :c0_0c2s4n0;
+	logset:hasPart :c0_0c2s4n1;
+	logset:hasPart :c0_0c2s4n2;
+	logset:hasPart :c0_0c2s4n3;
+	logset:hasPart :c0_0c2s4a0;
+	.
+
+:c0_0c2s8 a ddict:Blade ;
+	logset:hasPart :c0_0c2s8n0;
+	logset:hasPart :c0_0c2s8n1;
+	logset:hasPart :c0_0c2s8n2;
+	logset:hasPart :c0_0c2s8n3;
+	logset:hasPart :c0_0c2s8a0;
+	.
+
+:c0_0c2s9 a ddict:Blade ;
+	logset:hasPart :c0_0c2s9n0;
+	logset:hasPart :c0_0c2s9n1;
+	logset:hasPart :c0_0c2s9n2;
+	logset:hasPart :c0_0c2s9n3;
+	logset:hasPart :c0_0c2s9a0;
+	.
+
+:c1_0c0s0 a ddict:Blade ;
+	logset:hasPart :c1_0c0s0n0;
+	logset:hasPart :c1_0c0s0n1;
+	logset:hasPart :c1_0c0s0n2;
+	logset:hasPart :c1_0c0s0n3;
+	logset:hasPart :c1_0c0s0a0;
+	.
+
+:c1_0c0s1 a ddict:Blade ;
+	logset:hasPart :c1_0c0s1n0;
+	logset:hasPart :c1_0c0s1n1;
+	logset:hasPart :c1_0c0s1n2;
+	logset:hasPart :c1_0c0s1n3;
+	logset:hasPart :c1_0c0s1a0;
+	.
+
+:c1_0c0s10 a ddict:Blade ;
+	logset:hasPart :c1_0c0s10n0;
+	logset:hasPart :c1_0c0s10n1;
+	logset:hasPart :c1_0c0s10n2;
+	logset:hasPart :c1_0c0s10n3;
+	logset:hasPart :c1_0c0s10a0;
+	.
+
+:c1_0c0s11 a ddict:Blade ;
+	logset:hasPart :c1_0c0s11n0;
+	logset:hasPart :c1_0c0s11n1;
+	logset:hasPart :c1_0c0s11n2;
+	logset:hasPart :c1_0c0s11n3;
+	logset:hasPart :c1_0c0s11a0;
+	.
+
+:c1_0c0s12 a ddict:Blade ;
+	logset:hasPart :c1_0c0s12n0;
+	logset:hasPart :c1_0c0s12n1;
+	logset:hasPart :c1_0c0s12n2;
+	logset:hasPart :c1_0c0s12n3;
+	logset:hasPart :c1_0c0s12a0;
+	.
+
+:c1_0c0s13 a ddict:Blade ;
+	logset:hasPart :c1_0c0s13n0;
+	logset:hasPart :c1_0c0s13n1;
+	logset:hasPart :c1_0c0s13n2;
+	logset:hasPart :c1_0c0s13n3;
+	logset:hasPart :c1_0c0s13a0;
+	.
+
+:c1_0c0s14 a ddict:Blade ;
+	logset:hasPart :c1_0c0s14n0;
+	logset:hasPart :c1_0c0s14n1;
+	logset:hasPart :c1_0c0s14n2;
+	logset:hasPart :c1_0c0s14n3;
+	logset:hasPart :c1_0c0s14a0;
+	.
+
+:c1_0c0s15 a ddict:Blade ;
+	logset:hasPart :c1_0c0s15n0;
+	logset:hasPart :c1_0c0s15n1;
+	logset:hasPart :c1_0c0s15n2;
+	logset:hasPart :c1_0c0s15n3;
+	logset:hasPart :c1_0c0s15a0;
+	.
+
+:c1_0c0s2 a ddict:Blade ;
+	logset:hasPart :c1_0c0s2n0;
+	logset:hasPart :c1_0c0s2n1;
+	logset:hasPart :c1_0c0s2n2;
+	logset:hasPart :c1_0c0s2n3;
+	logset:hasPart :c1_0c0s2a0;
+	.
+
+:c1_0c0s3 a ddict:Blade ;
+	logset:hasPart :c1_0c0s3n0;
+	logset:hasPart :c1_0c0s3n1;
+	logset:hasPart :c1_0c0s3n2;
+	logset:hasPart :c1_0c0s3n3;
+	logset:hasPart :c1_0c0s3a0;
+	.
+
+:c1_0c0s4 a ddict:Blade ;
+	logset:hasPart :c1_0c0s4n0;
+	logset:hasPart :c1_0c0s4n1;
+	logset:hasPart :c1_0c0s4n2;
+	logset:hasPart :c1_0c0s4n3;
+	logset:hasPart :c1_0c0s4a0;
+	.
+
+:c1_0c0s5 a ddict:Blade ;
+	logset:hasPart :c1_0c0s5n0;
+	logset:hasPart :c1_0c0s5n1;
+	logset:hasPart :c1_0c0s5n2;
+	logset:hasPart :c1_0c0s5n3;
+	logset:hasPart :c1_0c0s5a0;
+	.
+
+:c1_0c0s6 a ddict:Blade ;
+	logset:hasPart :c1_0c0s6n0;
+	logset:hasPart :c1_0c0s6n1;
+	logset:hasPart :c1_0c0s6n2;
+	logset:hasPart :c1_0c0s6n3;
+	logset:hasPart :c1_0c0s6a0;
+	.
+
+:c1_0c0s7 a ddict:Blade ;
+	logset:hasPart :c1_0c0s7n0;
+	logset:hasPart :c1_0c0s7n1;
+	logset:hasPart :c1_0c0s7n2;
+	logset:hasPart :c1_0c0s7n3;
+	logset:hasPart :c1_0c0s7a0;
+	.
+
+:c1_0c0s8 a ddict:Blade ;
+	logset:hasPart :c1_0c0s8n0;
+	logset:hasPart :c1_0c0s8n1;
+	logset:hasPart :c1_0c0s8n2;
+	logset:hasPart :c1_0c0s8n3;
+	logset:hasPart :c1_0c0s8a0;
+	.
+
+:c1_0c0s9 a ddict:Blade ;
+	logset:hasPart :c1_0c0s9n0;
+	logset:hasPart :c1_0c0s9n1;
+	logset:hasPart :c1_0c0s9n2;
+	logset:hasPart :c1_0c0s9n3;
+	logset:hasPart :c1_0c0s9a0;
+	.
+
+:c1_0c1s0 a ddict:Blade ;
+	logset:hasPart :c1_0c1s0n0;
+	logset:hasPart :c1_0c1s0n1;
+	logset:hasPart :c1_0c1s0n2;
+	logset:hasPart :c1_0c1s0n3;
+	logset:hasPart :c1_0c1s0a0;
+	.
+
+:c1_0c1s1 a ddict:Blade ;
+	logset:hasPart :c1_0c1s1n0;
+	logset:hasPart :c1_0c1s1n1;
+	logset:hasPart :c1_0c1s1n2;
+	logset:hasPart :c1_0c1s1n3;
+	logset:hasPart :c1_0c1s1a0;
+	.
+
+:c1_0c1s10 a ddict:Blade ;
+	logset:hasPart :c1_0c1s10n0;
+	logset:hasPart :c1_0c1s10n1;
+	logset:hasPart :c1_0c1s10n2;
+	logset:hasPart :c1_0c1s10n3;
+	logset:hasPart :c1_0c1s10a0;
+	.
+
+:c1_0c1s11 a ddict:Blade ;
+	logset:hasPart :c1_0c1s11n0;
+	logset:hasPart :c1_0c1s11n1;
+	logset:hasPart :c1_0c1s11n2;
+	logset:hasPart :c1_0c1s11n3;
+	logset:hasPart :c1_0c1s11a0;
+	.
+
+:c1_0c1s12 a ddict:Blade ;
+	logset:hasPart :c1_0c1s12n0;
+	logset:hasPart :c1_0c1s12n1;
+	logset:hasPart :c1_0c1s12n2;
+	logset:hasPart :c1_0c1s12n3;
+	logset:hasPart :c1_0c1s12a0;
+	.
+
+:c1_0c1s13 a ddict:Blade ;
+	logset:hasPart :c1_0c1s13n0;
+	logset:hasPart :c1_0c1s13n1;
+	logset:hasPart :c1_0c1s13n2;
+	logset:hasPart :c1_0c1s13n3;
+	logset:hasPart :c1_0c1s13a0;
+	.
+
+:c1_0c1s2 a ddict:Blade ;
+	logset:hasPart :c1_0c1s2n0;
+	logset:hasPart :c1_0c1s2n1;
+	logset:hasPart :c1_0c1s2n2;
+	logset:hasPart :c1_0c1s2n3;
+	logset:hasPart :c1_0c1s2a0;
+	.
+
+:c1_0c1s3 a ddict:Blade ;
+	logset:hasPart :c1_0c1s3n0;
+	logset:hasPart :c1_0c1s3n1;
+	logset:hasPart :c1_0c1s3n2;
+	logset:hasPart :c1_0c1s3n3;
+	logset:hasPart :c1_0c1s3a0;
+	.
+
+:c1_0c1s4 a ddict:Blade ;
+	logset:hasPart :c1_0c1s4n0;
+	logset:hasPart :c1_0c1s4n1;
+	logset:hasPart :c1_0c1s4n2;
+	logset:hasPart :c1_0c1s4n3;
+	logset:hasPart :c1_0c1s4a0;
+	.
+
+:c1_0c1s5 a ddict:Blade ;
+	logset:hasPart :c1_0c1s5n0;
+	logset:hasPart :c1_0c1s5n1;
+	logset:hasPart :c1_0c1s5n2;
+	logset:hasPart :c1_0c1s5n3;
+	logset:hasPart :c1_0c1s5a0;
+	.
+
+:c1_0c1s6 a ddict:Blade ;
+	logset:hasPart :c1_0c1s6n0;
+	logset:hasPart :c1_0c1s6n1;
+	logset:hasPart :c1_0c1s6n2;
+	logset:hasPart :c1_0c1s6n3;
+	logset:hasPart :c1_0c1s6a0;
+	.
+
+:c1_0c1s7 a ddict:Blade ;
+	logset:hasPart :c1_0c1s7n0;
+	logset:hasPart :c1_0c1s7n1;
+	logset:hasPart :c1_0c1s7n2;
+	logset:hasPart :c1_0c1s7n3;
+	logset:hasPart :c1_0c1s7a0;
+	.
+
+:c1_0c1s8 a ddict:Blade ;
+	logset:hasPart :c1_0c1s8n0;
+	logset:hasPart :c1_0c1s8n1;
+	logset:hasPart :c1_0c1s8n2;
+	logset:hasPart :c1_0c1s8n3;
+	logset:hasPart :c1_0c1s8a0;
+	.
+
+:c1_0c1s9 a ddict:Blade ;
+	logset:hasPart :c1_0c1s9n0;
+	logset:hasPart :c1_0c1s9n1;
+	logset:hasPart :c1_0c1s9n2;
+	logset:hasPart :c1_0c1s9n3;
+	logset:hasPart :c1_0c1s9a0;
+	.
+
+:c0_0c0s0a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s0a0l00;
+	logset:hasPart :c0_0c0s0a0l01;
+	logset:hasPart :c0_0c0s0a0l02;
+	logset:hasPart :c0_0c0s0a0l03;
+	logset:hasPart :c0_0c0s0a0l04;
+	logset:hasPart :c0_0c0s0a0l05;
+	logset:hasPart :c0_0c0s0a0l06;
+	logset:hasPart :c0_0c0s0a0l07;
+	logset:hasPart :c0_0c0s0a0l10;
+	logset:hasPart :c0_0c0s0a0l11;
+	logset:hasPart :c0_0c0s0a0l12;
+	logset:hasPart :c0_0c0s0a0l13;
+	logset:hasPart :c0_0c0s0a0l14;
+	logset:hasPart :c0_0c0s0a0l15;
+	logset:hasPart :c0_0c0s0a0l16;
+	logset:hasPart :c0_0c0s0a0l17;
+	logset:hasPart :c0_0c0s0a0l20;
+	logset:hasPart :c0_0c0s0a0l21;
+	logset:hasPart :c0_0c0s0a0l22;
+	logset:hasPart :c0_0c0s0a0l23;
+	logset:hasPart :c0_0c0s0a0l24;
+	logset:hasPart :c0_0c0s0a0l25;
+	logset:hasPart :c0_0c0s0a0l26;
+	logset:hasPart :c0_0c0s0a0l27;
+	logset:hasPart :c0_0c0s0a0l30;
+	logset:hasPart :c0_0c0s0a0l31;
+	logset:hasPart :c0_0c0s0a0l32;
+	logset:hasPart :c0_0c0s0a0l33;
+	logset:hasPart :c0_0c0s0a0l34;
+	logset:hasPart :c0_0c0s0a0l35;
+	logset:hasPart :c0_0c0s0a0l36;
+	logset:hasPart :c0_0c0s0a0l37;
+	logset:hasPart :c0_0c0s0a0l40;
+	logset:hasPart :c0_0c0s0a0l41;
+	logset:hasPart :c0_0c0s0a0l42;
+	logset:hasPart :c0_0c0s0a0l43;
+	logset:hasPart :c0_0c0s0a0l44;
+	logset:hasPart :c0_0c0s0a0l45;
+	logset:hasPart :c0_0c0s0a0l46;
+	logset:hasPart :c0_0c0s0a0l47;
+	logset:hasPart :c0_0c0s0a0l50;
+	logset:hasPart :c0_0c0s0a0l51;
+	logset:hasPart :c0_0c0s0a0l52;
+	logset:hasPart :c0_0c0s0a0l53;
+	logset:hasPart :c0_0c0s0a0l54;
+	logset:hasPart :c0_0c0s0a0l55;
+	logset:hasPart :c0_0c0s0a0l56;
+	logset:hasPart :c0_0c0s0a0l57;
+	logset:hasPart :c0_0c0s0a0n0;
+	logset:hasPart :c0_0c0s0a0n1;
+	logset:hasPart :c0_0c0s0a0n2;
+	logset:hasPart :c0_0c0s0a0n3;
+	.
+
+:c0_0c0s10a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s10a0l00;
+	logset:hasPart :c0_0c0s10a0l01;
+	logset:hasPart :c0_0c0s10a0l02;
+	logset:hasPart :c0_0c0s10a0l03;
+	logset:hasPart :c0_0c0s10a0l04;
+	logset:hasPart :c0_0c0s10a0l05;
+	logset:hasPart :c0_0c0s10a0l06;
+	logset:hasPart :c0_0c0s10a0l07;
+	logset:hasPart :c0_0c0s10a0l10;
+	logset:hasPart :c0_0c0s10a0l11;
+	logset:hasPart :c0_0c0s10a0l12;
+	logset:hasPart :c0_0c0s10a0l13;
+	logset:hasPart :c0_0c0s10a0l14;
+	logset:hasPart :c0_0c0s10a0l15;
+	logset:hasPart :c0_0c0s10a0l16;
+	logset:hasPart :c0_0c0s10a0l17;
+	logset:hasPart :c0_0c0s10a0l20;
+	logset:hasPart :c0_0c0s10a0l21;
+	logset:hasPart :c0_0c0s10a0l22;
+	logset:hasPart :c0_0c0s10a0l23;
+	logset:hasPart :c0_0c0s10a0l24;
+	logset:hasPart :c0_0c0s10a0l25;
+	logset:hasPart :c0_0c0s10a0l26;
+	logset:hasPart :c0_0c0s10a0l27;
+	logset:hasPart :c0_0c0s10a0l30;
+	logset:hasPart :c0_0c0s10a0l31;
+	logset:hasPart :c0_0c0s10a0l32;
+	logset:hasPart :c0_0c0s10a0l33;
+	logset:hasPart :c0_0c0s10a0l34;
+	logset:hasPart :c0_0c0s10a0l35;
+	logset:hasPart :c0_0c0s10a0l36;
+	logset:hasPart :c0_0c0s10a0l37;
+	logset:hasPart :c0_0c0s10a0l40;
+	logset:hasPart :c0_0c0s10a0l41;
+	logset:hasPart :c0_0c0s10a0l42;
+	logset:hasPart :c0_0c0s10a0l43;
+	logset:hasPart :c0_0c0s10a0l44;
+	logset:hasPart :c0_0c0s10a0l45;
+	logset:hasPart :c0_0c0s10a0l46;
+	logset:hasPart :c0_0c0s10a0l47;
+	logset:hasPart :c0_0c0s10a0l50;
+	logset:hasPart :c0_0c0s10a0l51;
+	logset:hasPart :c0_0c0s10a0l52;
+	logset:hasPart :c0_0c0s10a0l53;
+	logset:hasPart :c0_0c0s10a0l54;
+	logset:hasPart :c0_0c0s10a0l55;
+	logset:hasPart :c0_0c0s10a0l56;
+	logset:hasPart :c0_0c0s10a0l57;
+	logset:hasPart :c0_0c0s10a0n0;
+	logset:hasPart :c0_0c0s10a0n1;
+	logset:hasPart :c0_0c0s10a0n2;
+	logset:hasPart :c0_0c0s10a0n3;
+	.
+
+:c0_0c0s11a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s11a0l00;
+	logset:hasPart :c0_0c0s11a0l01;
+	logset:hasPart :c0_0c0s11a0l02;
+	logset:hasPart :c0_0c0s11a0l03;
+	logset:hasPart :c0_0c0s11a0l04;
+	logset:hasPart :c0_0c0s11a0l05;
+	logset:hasPart :c0_0c0s11a0l06;
+	logset:hasPart :c0_0c0s11a0l07;
+	logset:hasPart :c0_0c0s11a0l10;
+	logset:hasPart :c0_0c0s11a0l11;
+	logset:hasPart :c0_0c0s11a0l12;
+	logset:hasPart :c0_0c0s11a0l13;
+	logset:hasPart :c0_0c0s11a0l14;
+	logset:hasPart :c0_0c0s11a0l15;
+	logset:hasPart :c0_0c0s11a0l16;
+	logset:hasPart :c0_0c0s11a0l17;
+	logset:hasPart :c0_0c0s11a0l20;
+	logset:hasPart :c0_0c0s11a0l21;
+	logset:hasPart :c0_0c0s11a0l22;
+	logset:hasPart :c0_0c0s11a0l23;
+	logset:hasPart :c0_0c0s11a0l24;
+	logset:hasPart :c0_0c0s11a0l25;
+	logset:hasPart :c0_0c0s11a0l26;
+	logset:hasPart :c0_0c0s11a0l27;
+	logset:hasPart :c0_0c0s11a0l30;
+	logset:hasPart :c0_0c0s11a0l31;
+	logset:hasPart :c0_0c0s11a0l32;
+	logset:hasPart :c0_0c0s11a0l33;
+	logset:hasPart :c0_0c0s11a0l34;
+	logset:hasPart :c0_0c0s11a0l35;
+	logset:hasPart :c0_0c0s11a0l36;
+	logset:hasPart :c0_0c0s11a0l37;
+	logset:hasPart :c0_0c0s11a0l40;
+	logset:hasPart :c0_0c0s11a0l41;
+	logset:hasPart :c0_0c0s11a0l42;
+	logset:hasPart :c0_0c0s11a0l43;
+	logset:hasPart :c0_0c0s11a0l44;
+	logset:hasPart :c0_0c0s11a0l45;
+	logset:hasPart :c0_0c0s11a0l46;
+	logset:hasPart :c0_0c0s11a0l47;
+	logset:hasPart :c0_0c0s11a0l50;
+	logset:hasPart :c0_0c0s11a0l51;
+	logset:hasPart :c0_0c0s11a0l52;
+	logset:hasPart :c0_0c0s11a0l53;
+	logset:hasPart :c0_0c0s11a0l54;
+	logset:hasPart :c0_0c0s11a0l55;
+	logset:hasPart :c0_0c0s11a0l56;
+	logset:hasPart :c0_0c0s11a0l57;
+	logset:hasPart :c0_0c0s11a0n0;
+	logset:hasPart :c0_0c0s11a0n1;
+	logset:hasPart :c0_0c0s11a0n2;
+	logset:hasPart :c0_0c0s11a0n3;
+	.
+
+:c0_0c0s1a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s1a0l00;
+	logset:hasPart :c0_0c0s1a0l01;
+	logset:hasPart :c0_0c0s1a0l02;
+	logset:hasPart :c0_0c0s1a0l03;
+	logset:hasPart :c0_0c0s1a0l04;
+	logset:hasPart :c0_0c0s1a0l05;
+	logset:hasPart :c0_0c0s1a0l06;
+	logset:hasPart :c0_0c0s1a0l07;
+	logset:hasPart :c0_0c0s1a0l10;
+	logset:hasPart :c0_0c0s1a0l11;
+	logset:hasPart :c0_0c0s1a0l12;
+	logset:hasPart :c0_0c0s1a0l13;
+	logset:hasPart :c0_0c0s1a0l14;
+	logset:hasPart :c0_0c0s1a0l15;
+	logset:hasPart :c0_0c0s1a0l16;
+	logset:hasPart :c0_0c0s1a0l17;
+	logset:hasPart :c0_0c0s1a0l20;
+	logset:hasPart :c0_0c0s1a0l21;
+	logset:hasPart :c0_0c0s1a0l22;
+	logset:hasPart :c0_0c0s1a0l23;
+	logset:hasPart :c0_0c0s1a0l24;
+	logset:hasPart :c0_0c0s1a0l25;
+	logset:hasPart :c0_0c0s1a0l26;
+	logset:hasPart :c0_0c0s1a0l27;
+	logset:hasPart :c0_0c0s1a0l30;
+	logset:hasPart :c0_0c0s1a0l31;
+	logset:hasPart :c0_0c0s1a0l32;
+	logset:hasPart :c0_0c0s1a0l33;
+	logset:hasPart :c0_0c0s1a0l34;
+	logset:hasPart :c0_0c0s1a0l35;
+	logset:hasPart :c0_0c0s1a0l36;
+	logset:hasPart :c0_0c0s1a0l37;
+	logset:hasPart :c0_0c0s1a0l40;
+	logset:hasPart :c0_0c0s1a0l41;
+	logset:hasPart :c0_0c0s1a0l42;
+	logset:hasPart :c0_0c0s1a0l43;
+	logset:hasPart :c0_0c0s1a0l44;
+	logset:hasPart :c0_0c0s1a0l45;
+	logset:hasPart :c0_0c0s1a0l46;
+	logset:hasPart :c0_0c0s1a0l47;
+	logset:hasPart :c0_0c0s1a0l50;
+	logset:hasPart :c0_0c0s1a0l51;
+	logset:hasPart :c0_0c0s1a0l52;
+	logset:hasPart :c0_0c0s1a0l53;
+	logset:hasPart :c0_0c0s1a0l54;
+	logset:hasPart :c0_0c0s1a0l55;
+	logset:hasPart :c0_0c0s1a0l56;
+	logset:hasPart :c0_0c0s1a0l57;
+	logset:hasPart :c0_0c0s1a0n0;
+	logset:hasPart :c0_0c0s1a0n1;
+	logset:hasPart :c0_0c0s1a0n2;
+	logset:hasPart :c0_0c0s1a0n3;
+	.
+
+:c0_0c0s2a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s2a0l00;
+	logset:hasPart :c0_0c0s2a0l01;
+	logset:hasPart :c0_0c0s2a0l02;
+	logset:hasPart :c0_0c0s2a0l03;
+	logset:hasPart :c0_0c0s2a0l04;
+	logset:hasPart :c0_0c0s2a0l05;
+	logset:hasPart :c0_0c0s2a0l06;
+	logset:hasPart :c0_0c0s2a0l07;
+	logset:hasPart :c0_0c0s2a0l10;
+	logset:hasPart :c0_0c0s2a0l11;
+	logset:hasPart :c0_0c0s2a0l12;
+	logset:hasPart :c0_0c0s2a0l13;
+	logset:hasPart :c0_0c0s2a0l14;
+	logset:hasPart :c0_0c0s2a0l15;
+	logset:hasPart :c0_0c0s2a0l16;
+	logset:hasPart :c0_0c0s2a0l17;
+	logset:hasPart :c0_0c0s2a0l20;
+	logset:hasPart :c0_0c0s2a0l21;
+	logset:hasPart :c0_0c0s2a0l22;
+	logset:hasPart :c0_0c0s2a0l23;
+	logset:hasPart :c0_0c0s2a0l24;
+	logset:hasPart :c0_0c0s2a0l25;
+	logset:hasPart :c0_0c0s2a0l26;
+	logset:hasPart :c0_0c0s2a0l27;
+	logset:hasPart :c0_0c0s2a0l30;
+	logset:hasPart :c0_0c0s2a0l31;
+	logset:hasPart :c0_0c0s2a0l32;
+	logset:hasPart :c0_0c0s2a0l33;
+	logset:hasPart :c0_0c0s2a0l34;
+	logset:hasPart :c0_0c0s2a0l35;
+	logset:hasPart :c0_0c0s2a0l36;
+	logset:hasPart :c0_0c0s2a0l37;
+	logset:hasPart :c0_0c0s2a0l40;
+	logset:hasPart :c0_0c0s2a0l41;
+	logset:hasPart :c0_0c0s2a0l42;
+	logset:hasPart :c0_0c0s2a0l43;
+	logset:hasPart :c0_0c0s2a0l44;
+	logset:hasPart :c0_0c0s2a0l45;
+	logset:hasPart :c0_0c0s2a0l46;
+	logset:hasPart :c0_0c0s2a0l47;
+	logset:hasPart :c0_0c0s2a0l50;
+	logset:hasPart :c0_0c0s2a0l51;
+	logset:hasPart :c0_0c0s2a0l52;
+	logset:hasPart :c0_0c0s2a0l53;
+	logset:hasPart :c0_0c0s2a0l54;
+	logset:hasPart :c0_0c0s2a0l55;
+	logset:hasPart :c0_0c0s2a0l56;
+	logset:hasPart :c0_0c0s2a0l57;
+	logset:hasPart :c0_0c0s2a0n0;
+	logset:hasPart :c0_0c0s2a0n1;
+	logset:hasPart :c0_0c0s2a0n2;
+	logset:hasPart :c0_0c0s2a0n3;
+	.
+
+:c0_0c0s3a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s3a0l00;
+	logset:hasPart :c0_0c0s3a0l01;
+	logset:hasPart :c0_0c0s3a0l02;
+	logset:hasPart :c0_0c0s3a0l03;
+	logset:hasPart :c0_0c0s3a0l04;
+	logset:hasPart :c0_0c0s3a0l05;
+	logset:hasPart :c0_0c0s3a0l06;
+	logset:hasPart :c0_0c0s3a0l07;
+	logset:hasPart :c0_0c0s3a0l10;
+	logset:hasPart :c0_0c0s3a0l11;
+	logset:hasPart :c0_0c0s3a0l12;
+	logset:hasPart :c0_0c0s3a0l13;
+	logset:hasPart :c0_0c0s3a0l14;
+	logset:hasPart :c0_0c0s3a0l15;
+	logset:hasPart :c0_0c0s3a0l16;
+	logset:hasPart :c0_0c0s3a0l17;
+	logset:hasPart :c0_0c0s3a0l20;
+	logset:hasPart :c0_0c0s3a0l21;
+	logset:hasPart :c0_0c0s3a0l22;
+	logset:hasPart :c0_0c0s3a0l23;
+	logset:hasPart :c0_0c0s3a0l24;
+	logset:hasPart :c0_0c0s3a0l25;
+	logset:hasPart :c0_0c0s3a0l26;
+	logset:hasPart :c0_0c0s3a0l27;
+	logset:hasPart :c0_0c0s3a0l30;
+	logset:hasPart :c0_0c0s3a0l31;
+	logset:hasPart :c0_0c0s3a0l32;
+	logset:hasPart :c0_0c0s3a0l33;
+	logset:hasPart :c0_0c0s3a0l34;
+	logset:hasPart :c0_0c0s3a0l35;
+	logset:hasPart :c0_0c0s3a0l36;
+	logset:hasPart :c0_0c0s3a0l37;
+	logset:hasPart :c0_0c0s3a0l40;
+	logset:hasPart :c0_0c0s3a0l41;
+	logset:hasPart :c0_0c0s3a0l42;
+	logset:hasPart :c0_0c0s3a0l43;
+	logset:hasPart :c0_0c0s3a0l44;
+	logset:hasPart :c0_0c0s3a0l45;
+	logset:hasPart :c0_0c0s3a0l46;
+	logset:hasPart :c0_0c0s3a0l47;
+	logset:hasPart :c0_0c0s3a0l50;
+	logset:hasPart :c0_0c0s3a0l51;
+	logset:hasPart :c0_0c0s3a0l52;
+	logset:hasPart :c0_0c0s3a0l53;
+	logset:hasPart :c0_0c0s3a0l54;
+	logset:hasPart :c0_0c0s3a0l55;
+	logset:hasPart :c0_0c0s3a0l56;
+	logset:hasPart :c0_0c0s3a0l57;
+	logset:hasPart :c0_0c0s3a0n0;
+	logset:hasPart :c0_0c0s3a0n1;
+	logset:hasPart :c0_0c0s3a0n2;
+	logset:hasPart :c0_0c0s3a0n3;
+	.
+
+:c0_0c0s4a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s4a0l00;
+	logset:hasPart :c0_0c0s4a0l01;
+	logset:hasPart :c0_0c0s4a0l02;
+	logset:hasPart :c0_0c0s4a0l03;
+	logset:hasPart :c0_0c0s4a0l04;
+	logset:hasPart :c0_0c0s4a0l05;
+	logset:hasPart :c0_0c0s4a0l06;
+	logset:hasPart :c0_0c0s4a0l07;
+	logset:hasPart :c0_0c0s4a0l10;
+	logset:hasPart :c0_0c0s4a0l11;
+	logset:hasPart :c0_0c0s4a0l12;
+	logset:hasPart :c0_0c0s4a0l13;
+	logset:hasPart :c0_0c0s4a0l14;
+	logset:hasPart :c0_0c0s4a0l15;
+	logset:hasPart :c0_0c0s4a0l16;
+	logset:hasPart :c0_0c0s4a0l17;
+	logset:hasPart :c0_0c0s4a0l20;
+	logset:hasPart :c0_0c0s4a0l21;
+	logset:hasPart :c0_0c0s4a0l22;
+	logset:hasPart :c0_0c0s4a0l23;
+	logset:hasPart :c0_0c0s4a0l24;
+	logset:hasPart :c0_0c0s4a0l25;
+	logset:hasPart :c0_0c0s4a0l26;
+	logset:hasPart :c0_0c0s4a0l27;
+	logset:hasPart :c0_0c0s4a0l30;
+	logset:hasPart :c0_0c0s4a0l31;
+	logset:hasPart :c0_0c0s4a0l32;
+	logset:hasPart :c0_0c0s4a0l33;
+	logset:hasPart :c0_0c0s4a0l34;
+	logset:hasPart :c0_0c0s4a0l35;
+	logset:hasPart :c0_0c0s4a0l36;
+	logset:hasPart :c0_0c0s4a0l37;
+	logset:hasPart :c0_0c0s4a0l40;
+	logset:hasPart :c0_0c0s4a0l41;
+	logset:hasPart :c0_0c0s4a0l42;
+	logset:hasPart :c0_0c0s4a0l43;
+	logset:hasPart :c0_0c0s4a0l44;
+	logset:hasPart :c0_0c0s4a0l45;
+	logset:hasPart :c0_0c0s4a0l46;
+	logset:hasPart :c0_0c0s4a0l47;
+	logset:hasPart :c0_0c0s4a0l50;
+	logset:hasPart :c0_0c0s4a0l51;
+	logset:hasPart :c0_0c0s4a0l52;
+	logset:hasPart :c0_0c0s4a0l53;
+	logset:hasPart :c0_0c0s4a0l54;
+	logset:hasPart :c0_0c0s4a0l55;
+	logset:hasPart :c0_0c0s4a0l56;
+	logset:hasPart :c0_0c0s4a0l57;
+	logset:hasPart :c0_0c0s4a0n0;
+	logset:hasPart :c0_0c0s4a0n1;
+	logset:hasPart :c0_0c0s4a0n2;
+	logset:hasPart :c0_0c0s4a0n3;
+	.
+
+:c0_0c0s5a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s5a0l00;
+	logset:hasPart :c0_0c0s5a0l01;
+	logset:hasPart :c0_0c0s5a0l02;
+	logset:hasPart :c0_0c0s5a0l03;
+	logset:hasPart :c0_0c0s5a0l04;
+	logset:hasPart :c0_0c0s5a0l05;
+	logset:hasPart :c0_0c0s5a0l06;
+	logset:hasPart :c0_0c0s5a0l07;
+	logset:hasPart :c0_0c0s5a0l10;
+	logset:hasPart :c0_0c0s5a0l11;
+	logset:hasPart :c0_0c0s5a0l12;
+	logset:hasPart :c0_0c0s5a0l13;
+	logset:hasPart :c0_0c0s5a0l14;
+	logset:hasPart :c0_0c0s5a0l15;
+	logset:hasPart :c0_0c0s5a0l16;
+	logset:hasPart :c0_0c0s5a0l17;
+	logset:hasPart :c0_0c0s5a0l20;
+	logset:hasPart :c0_0c0s5a0l21;
+	logset:hasPart :c0_0c0s5a0l22;
+	logset:hasPart :c0_0c0s5a0l23;
+	logset:hasPart :c0_0c0s5a0l24;
+	logset:hasPart :c0_0c0s5a0l25;
+	logset:hasPart :c0_0c0s5a0l26;
+	logset:hasPart :c0_0c0s5a0l27;
+	logset:hasPart :c0_0c0s5a0l30;
+	logset:hasPart :c0_0c0s5a0l31;
+	logset:hasPart :c0_0c0s5a0l32;
+	logset:hasPart :c0_0c0s5a0l33;
+	logset:hasPart :c0_0c0s5a0l34;
+	logset:hasPart :c0_0c0s5a0l35;
+	logset:hasPart :c0_0c0s5a0l36;
+	logset:hasPart :c0_0c0s5a0l37;
+	logset:hasPart :c0_0c0s5a0l40;
+	logset:hasPart :c0_0c0s5a0l41;
+	logset:hasPart :c0_0c0s5a0l42;
+	logset:hasPart :c0_0c0s5a0l43;
+	logset:hasPart :c0_0c0s5a0l44;
+	logset:hasPart :c0_0c0s5a0l45;
+	logset:hasPart :c0_0c0s5a0l46;
+	logset:hasPart :c0_0c0s5a0l47;
+	logset:hasPart :c0_0c0s5a0l50;
+	logset:hasPart :c0_0c0s5a0l51;
+	logset:hasPart :c0_0c0s5a0l52;
+	logset:hasPart :c0_0c0s5a0l53;
+	logset:hasPart :c0_0c0s5a0l54;
+	logset:hasPart :c0_0c0s5a0l55;
+	logset:hasPart :c0_0c0s5a0l56;
+	logset:hasPart :c0_0c0s5a0l57;
+	logset:hasPart :c0_0c0s5a0n0;
+	logset:hasPart :c0_0c0s5a0n1;
+	logset:hasPart :c0_0c0s5a0n2;
+	logset:hasPart :c0_0c0s5a0n3;
+	.
+
+:c0_0c0s6a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s6a0l00;
+	logset:hasPart :c0_0c0s6a0l01;
+	logset:hasPart :c0_0c0s6a0l02;
+	logset:hasPart :c0_0c0s6a0l03;
+	logset:hasPart :c0_0c0s6a0l04;
+	logset:hasPart :c0_0c0s6a0l05;
+	logset:hasPart :c0_0c0s6a0l06;
+	logset:hasPart :c0_0c0s6a0l07;
+	logset:hasPart :c0_0c0s6a0l10;
+	logset:hasPart :c0_0c0s6a0l11;
+	logset:hasPart :c0_0c0s6a0l12;
+	logset:hasPart :c0_0c0s6a0l13;
+	logset:hasPart :c0_0c0s6a0l14;
+	logset:hasPart :c0_0c0s6a0l15;
+	logset:hasPart :c0_0c0s6a0l16;
+	logset:hasPart :c0_0c0s6a0l17;
+	logset:hasPart :c0_0c0s6a0l20;
+	logset:hasPart :c0_0c0s6a0l21;
+	logset:hasPart :c0_0c0s6a0l22;
+	logset:hasPart :c0_0c0s6a0l23;
+	logset:hasPart :c0_0c0s6a0l24;
+	logset:hasPart :c0_0c0s6a0l25;
+	logset:hasPart :c0_0c0s6a0l26;
+	logset:hasPart :c0_0c0s6a0l27;
+	logset:hasPart :c0_0c0s6a0l30;
+	logset:hasPart :c0_0c0s6a0l31;
+	logset:hasPart :c0_0c0s6a0l32;
+	logset:hasPart :c0_0c0s6a0l33;
+	logset:hasPart :c0_0c0s6a0l34;
+	logset:hasPart :c0_0c0s6a0l35;
+	logset:hasPart :c0_0c0s6a0l36;
+	logset:hasPart :c0_0c0s6a0l37;
+	logset:hasPart :c0_0c0s6a0l40;
+	logset:hasPart :c0_0c0s6a0l41;
+	logset:hasPart :c0_0c0s6a0l42;
+	logset:hasPart :c0_0c0s6a0l43;
+	logset:hasPart :c0_0c0s6a0l44;
+	logset:hasPart :c0_0c0s6a0l45;
+	logset:hasPart :c0_0c0s6a0l46;
+	logset:hasPart :c0_0c0s6a0l47;
+	logset:hasPart :c0_0c0s6a0l50;
+	logset:hasPart :c0_0c0s6a0l51;
+	logset:hasPart :c0_0c0s6a0l52;
+	logset:hasPart :c0_0c0s6a0l53;
+	logset:hasPart :c0_0c0s6a0l54;
+	logset:hasPart :c0_0c0s6a0l55;
+	logset:hasPart :c0_0c0s6a0l56;
+	logset:hasPart :c0_0c0s6a0l57;
+	logset:hasPart :c0_0c0s6a0n0;
+	logset:hasPart :c0_0c0s6a0n1;
+	logset:hasPart :c0_0c0s6a0n2;
+	logset:hasPart :c0_0c0s6a0n3;
+	.
+
+:c0_0c0s7a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s7a0l00;
+	logset:hasPart :c0_0c0s7a0l01;
+	logset:hasPart :c0_0c0s7a0l02;
+	logset:hasPart :c0_0c0s7a0l03;
+	logset:hasPart :c0_0c0s7a0l04;
+	logset:hasPart :c0_0c0s7a0l05;
+	logset:hasPart :c0_0c0s7a0l06;
+	logset:hasPart :c0_0c0s7a0l07;
+	logset:hasPart :c0_0c0s7a0l10;
+	logset:hasPart :c0_0c0s7a0l11;
+	logset:hasPart :c0_0c0s7a0l12;
+	logset:hasPart :c0_0c0s7a0l13;
+	logset:hasPart :c0_0c0s7a0l14;
+	logset:hasPart :c0_0c0s7a0l15;
+	logset:hasPart :c0_0c0s7a0l16;
+	logset:hasPart :c0_0c0s7a0l17;
+	logset:hasPart :c0_0c0s7a0l20;
+	logset:hasPart :c0_0c0s7a0l21;
+	logset:hasPart :c0_0c0s7a0l22;
+	logset:hasPart :c0_0c0s7a0l23;
+	logset:hasPart :c0_0c0s7a0l24;
+	logset:hasPart :c0_0c0s7a0l25;
+	logset:hasPart :c0_0c0s7a0l26;
+	logset:hasPart :c0_0c0s7a0l27;
+	logset:hasPart :c0_0c0s7a0l30;
+	logset:hasPart :c0_0c0s7a0l31;
+	logset:hasPart :c0_0c0s7a0l32;
+	logset:hasPart :c0_0c0s7a0l33;
+	logset:hasPart :c0_0c0s7a0l34;
+	logset:hasPart :c0_0c0s7a0l35;
+	logset:hasPart :c0_0c0s7a0l36;
+	logset:hasPart :c0_0c0s7a0l37;
+	logset:hasPart :c0_0c0s7a0l40;
+	logset:hasPart :c0_0c0s7a0l41;
+	logset:hasPart :c0_0c0s7a0l42;
+	logset:hasPart :c0_0c0s7a0l43;
+	logset:hasPart :c0_0c0s7a0l44;
+	logset:hasPart :c0_0c0s7a0l45;
+	logset:hasPart :c0_0c0s7a0l46;
+	logset:hasPart :c0_0c0s7a0l47;
+	logset:hasPart :c0_0c0s7a0l50;
+	logset:hasPart :c0_0c0s7a0l51;
+	logset:hasPart :c0_0c0s7a0l52;
+	logset:hasPart :c0_0c0s7a0l53;
+	logset:hasPart :c0_0c0s7a0l54;
+	logset:hasPart :c0_0c0s7a0l55;
+	logset:hasPart :c0_0c0s7a0l56;
+	logset:hasPart :c0_0c0s7a0l57;
+	logset:hasPart :c0_0c0s7a0n0;
+	logset:hasPart :c0_0c0s7a0n1;
+	logset:hasPart :c0_0c0s7a0n2;
+	logset:hasPart :c0_0c0s7a0n3;
+	.
+
+:c0_0c0s8a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s8a0l00;
+	logset:hasPart :c0_0c0s8a0l01;
+	logset:hasPart :c0_0c0s8a0l02;
+	logset:hasPart :c0_0c0s8a0l03;
+	logset:hasPart :c0_0c0s8a0l04;
+	logset:hasPart :c0_0c0s8a0l05;
+	logset:hasPart :c0_0c0s8a0l06;
+	logset:hasPart :c0_0c0s8a0l07;
+	logset:hasPart :c0_0c0s8a0l10;
+	logset:hasPart :c0_0c0s8a0l11;
+	logset:hasPart :c0_0c0s8a0l12;
+	logset:hasPart :c0_0c0s8a0l13;
+	logset:hasPart :c0_0c0s8a0l14;
+	logset:hasPart :c0_0c0s8a0l15;
+	logset:hasPart :c0_0c0s8a0l16;
+	logset:hasPart :c0_0c0s8a0l17;
+	logset:hasPart :c0_0c0s8a0l20;
+	logset:hasPart :c0_0c0s8a0l21;
+	logset:hasPart :c0_0c0s8a0l22;
+	logset:hasPart :c0_0c0s8a0l23;
+	logset:hasPart :c0_0c0s8a0l24;
+	logset:hasPart :c0_0c0s8a0l25;
+	logset:hasPart :c0_0c0s8a0l26;
+	logset:hasPart :c0_0c0s8a0l27;
+	logset:hasPart :c0_0c0s8a0l30;
+	logset:hasPart :c0_0c0s8a0l31;
+	logset:hasPart :c0_0c0s8a0l32;
+	logset:hasPart :c0_0c0s8a0l33;
+	logset:hasPart :c0_0c0s8a0l34;
+	logset:hasPart :c0_0c0s8a0l35;
+	logset:hasPart :c0_0c0s8a0l36;
+	logset:hasPart :c0_0c0s8a0l37;
+	logset:hasPart :c0_0c0s8a0l40;
+	logset:hasPart :c0_0c0s8a0l41;
+	logset:hasPart :c0_0c0s8a0l42;
+	logset:hasPart :c0_0c0s8a0l43;
+	logset:hasPart :c0_0c0s8a0l44;
+	logset:hasPart :c0_0c0s8a0l45;
+	logset:hasPart :c0_0c0s8a0l46;
+	logset:hasPart :c0_0c0s8a0l47;
+	logset:hasPart :c0_0c0s8a0l50;
+	logset:hasPart :c0_0c0s8a0l51;
+	logset:hasPart :c0_0c0s8a0l52;
+	logset:hasPart :c0_0c0s8a0l53;
+	logset:hasPart :c0_0c0s8a0l54;
+	logset:hasPart :c0_0c0s8a0l55;
+	logset:hasPart :c0_0c0s8a0l56;
+	logset:hasPart :c0_0c0s8a0l57;
+	logset:hasPart :c0_0c0s8a0n0;
+	logset:hasPart :c0_0c0s8a0n1;
+	logset:hasPart :c0_0c0s8a0n2;
+	logset:hasPart :c0_0c0s8a0n3;
+	.
+
+:c0_0c0s9a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c0s9a0l00;
+	logset:hasPart :c0_0c0s9a0l01;
+	logset:hasPart :c0_0c0s9a0l02;
+	logset:hasPart :c0_0c0s9a0l03;
+	logset:hasPart :c0_0c0s9a0l04;
+	logset:hasPart :c0_0c0s9a0l05;
+	logset:hasPart :c0_0c0s9a0l06;
+	logset:hasPart :c0_0c0s9a0l07;
+	logset:hasPart :c0_0c0s9a0l10;
+	logset:hasPart :c0_0c0s9a0l11;
+	logset:hasPart :c0_0c0s9a0l12;
+	logset:hasPart :c0_0c0s9a0l13;
+	logset:hasPart :c0_0c0s9a0l14;
+	logset:hasPart :c0_0c0s9a0l15;
+	logset:hasPart :c0_0c0s9a0l16;
+	logset:hasPart :c0_0c0s9a0l17;
+	logset:hasPart :c0_0c0s9a0l20;
+	logset:hasPart :c0_0c0s9a0l21;
+	logset:hasPart :c0_0c0s9a0l22;
+	logset:hasPart :c0_0c0s9a0l23;
+	logset:hasPart :c0_0c0s9a0l24;
+	logset:hasPart :c0_0c0s9a0l25;
+	logset:hasPart :c0_0c0s9a0l26;
+	logset:hasPart :c0_0c0s9a0l27;
+	logset:hasPart :c0_0c0s9a0l30;
+	logset:hasPart :c0_0c0s9a0l31;
+	logset:hasPart :c0_0c0s9a0l32;
+	logset:hasPart :c0_0c0s9a0l33;
+	logset:hasPart :c0_0c0s9a0l34;
+	logset:hasPart :c0_0c0s9a0l35;
+	logset:hasPart :c0_0c0s9a0l36;
+	logset:hasPart :c0_0c0s9a0l37;
+	logset:hasPart :c0_0c0s9a0l40;
+	logset:hasPart :c0_0c0s9a0l41;
+	logset:hasPart :c0_0c0s9a0l42;
+	logset:hasPart :c0_0c0s9a0l43;
+	logset:hasPart :c0_0c0s9a0l44;
+	logset:hasPart :c0_0c0s9a0l45;
+	logset:hasPart :c0_0c0s9a0l46;
+	logset:hasPart :c0_0c0s9a0l47;
+	logset:hasPart :c0_0c0s9a0l50;
+	logset:hasPart :c0_0c0s9a0l51;
+	logset:hasPart :c0_0c0s9a0l52;
+	logset:hasPart :c0_0c0s9a0l53;
+	logset:hasPart :c0_0c0s9a0l54;
+	logset:hasPart :c0_0c0s9a0l55;
+	logset:hasPart :c0_0c0s9a0l56;
+	logset:hasPart :c0_0c0s9a0l57;
+	logset:hasPart :c0_0c0s9a0n0;
+	logset:hasPart :c0_0c0s9a0n1;
+	logset:hasPart :c0_0c0s9a0n2;
+	logset:hasPart :c0_0c0s9a0n3;
+	.
+
+:c0_0c1s0a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s0a0l00;
+	logset:hasPart :c0_0c1s0a0l01;
+	logset:hasPart :c0_0c1s0a0l02;
+	logset:hasPart :c0_0c1s0a0l03;
+	logset:hasPart :c0_0c1s0a0l04;
+	logset:hasPart :c0_0c1s0a0l05;
+	logset:hasPart :c0_0c1s0a0l06;
+	logset:hasPart :c0_0c1s0a0l07;
+	logset:hasPart :c0_0c1s0a0l10;
+	logset:hasPart :c0_0c1s0a0l11;
+	logset:hasPart :c0_0c1s0a0l12;
+	logset:hasPart :c0_0c1s0a0l13;
+	logset:hasPart :c0_0c1s0a0l14;
+	logset:hasPart :c0_0c1s0a0l15;
+	logset:hasPart :c0_0c1s0a0l16;
+	logset:hasPart :c0_0c1s0a0l17;
+	logset:hasPart :c0_0c1s0a0l20;
+	logset:hasPart :c0_0c1s0a0l21;
+	logset:hasPart :c0_0c1s0a0l22;
+	logset:hasPart :c0_0c1s0a0l23;
+	logset:hasPart :c0_0c1s0a0l24;
+	logset:hasPart :c0_0c1s0a0l25;
+	logset:hasPart :c0_0c1s0a0l26;
+	logset:hasPart :c0_0c1s0a0l27;
+	logset:hasPart :c0_0c1s0a0l30;
+	logset:hasPart :c0_0c1s0a0l31;
+	logset:hasPart :c0_0c1s0a0l32;
+	logset:hasPart :c0_0c1s0a0l33;
+	logset:hasPart :c0_0c1s0a0l34;
+	logset:hasPart :c0_0c1s0a0l35;
+	logset:hasPart :c0_0c1s0a0l36;
+	logset:hasPart :c0_0c1s0a0l37;
+	logset:hasPart :c0_0c1s0a0l40;
+	logset:hasPart :c0_0c1s0a0l41;
+	logset:hasPart :c0_0c1s0a0l42;
+	logset:hasPart :c0_0c1s0a0l43;
+	logset:hasPart :c0_0c1s0a0l44;
+	logset:hasPart :c0_0c1s0a0l45;
+	logset:hasPart :c0_0c1s0a0l46;
+	logset:hasPart :c0_0c1s0a0l47;
+	logset:hasPart :c0_0c1s0a0l50;
+	logset:hasPart :c0_0c1s0a0l51;
+	logset:hasPart :c0_0c1s0a0l52;
+	logset:hasPart :c0_0c1s0a0l53;
+	logset:hasPart :c0_0c1s0a0l54;
+	logset:hasPart :c0_0c1s0a0l55;
+	logset:hasPart :c0_0c1s0a0l56;
+	logset:hasPart :c0_0c1s0a0l57;
+	logset:hasPart :c0_0c1s0a0n0;
+	logset:hasPart :c0_0c1s0a0n1;
+	logset:hasPart :c0_0c1s0a0n2;
+	logset:hasPart :c0_0c1s0a0n3;
+	.
+
+:c0_0c1s10a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s10a0l00;
+	logset:hasPart :c0_0c1s10a0l01;
+	logset:hasPart :c0_0c1s10a0l02;
+	logset:hasPart :c0_0c1s10a0l03;
+	logset:hasPart :c0_0c1s10a0l04;
+	logset:hasPart :c0_0c1s10a0l05;
+	logset:hasPart :c0_0c1s10a0l06;
+	logset:hasPart :c0_0c1s10a0l07;
+	logset:hasPart :c0_0c1s10a0l10;
+	logset:hasPart :c0_0c1s10a0l11;
+	logset:hasPart :c0_0c1s10a0l12;
+	logset:hasPart :c0_0c1s10a0l13;
+	logset:hasPart :c0_0c1s10a0l14;
+	logset:hasPart :c0_0c1s10a0l15;
+	logset:hasPart :c0_0c1s10a0l16;
+	logset:hasPart :c0_0c1s10a0l17;
+	logset:hasPart :c0_0c1s10a0l20;
+	logset:hasPart :c0_0c1s10a0l21;
+	logset:hasPart :c0_0c1s10a0l22;
+	logset:hasPart :c0_0c1s10a0l23;
+	logset:hasPart :c0_0c1s10a0l24;
+	logset:hasPart :c0_0c1s10a0l25;
+	logset:hasPart :c0_0c1s10a0l26;
+	logset:hasPart :c0_0c1s10a0l27;
+	logset:hasPart :c0_0c1s10a0l30;
+	logset:hasPart :c0_0c1s10a0l31;
+	logset:hasPart :c0_0c1s10a0l32;
+	logset:hasPart :c0_0c1s10a0l33;
+	logset:hasPart :c0_0c1s10a0l34;
+	logset:hasPart :c0_0c1s10a0l35;
+	logset:hasPart :c0_0c1s10a0l36;
+	logset:hasPart :c0_0c1s10a0l37;
+	logset:hasPart :c0_0c1s10a0l40;
+	logset:hasPart :c0_0c1s10a0l41;
+	logset:hasPart :c0_0c1s10a0l42;
+	logset:hasPart :c0_0c1s10a0l43;
+	logset:hasPart :c0_0c1s10a0l44;
+	logset:hasPart :c0_0c1s10a0l45;
+	logset:hasPart :c0_0c1s10a0l46;
+	logset:hasPart :c0_0c1s10a0l47;
+	logset:hasPart :c0_0c1s10a0l50;
+	logset:hasPart :c0_0c1s10a0l51;
+	logset:hasPart :c0_0c1s10a0l52;
+	logset:hasPart :c0_0c1s10a0l53;
+	logset:hasPart :c0_0c1s10a0l54;
+	logset:hasPart :c0_0c1s10a0l55;
+	logset:hasPart :c0_0c1s10a0l56;
+	logset:hasPart :c0_0c1s10a0l57;
+	logset:hasPart :c0_0c1s10a0n0;
+	logset:hasPart :c0_0c1s10a0n1;
+	logset:hasPart :c0_0c1s10a0n2;
+	logset:hasPart :c0_0c1s10a0n3;
+	.
+
+:c0_0c1s11a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s11a0l00;
+	logset:hasPart :c0_0c1s11a0l01;
+	logset:hasPart :c0_0c1s11a0l02;
+	logset:hasPart :c0_0c1s11a0l03;
+	logset:hasPart :c0_0c1s11a0l04;
+	logset:hasPart :c0_0c1s11a0l05;
+	logset:hasPart :c0_0c1s11a0l06;
+	logset:hasPart :c0_0c1s11a0l07;
+	logset:hasPart :c0_0c1s11a0l10;
+	logset:hasPart :c0_0c1s11a0l11;
+	logset:hasPart :c0_0c1s11a0l12;
+	logset:hasPart :c0_0c1s11a0l13;
+	logset:hasPart :c0_0c1s11a0l14;
+	logset:hasPart :c0_0c1s11a0l15;
+	logset:hasPart :c0_0c1s11a0l16;
+	logset:hasPart :c0_0c1s11a0l17;
+	logset:hasPart :c0_0c1s11a0l20;
+	logset:hasPart :c0_0c1s11a0l21;
+	logset:hasPart :c0_0c1s11a0l22;
+	logset:hasPart :c0_0c1s11a0l23;
+	logset:hasPart :c0_0c1s11a0l24;
+	logset:hasPart :c0_0c1s11a0l25;
+	logset:hasPart :c0_0c1s11a0l26;
+	logset:hasPart :c0_0c1s11a0l27;
+	logset:hasPart :c0_0c1s11a0l30;
+	logset:hasPart :c0_0c1s11a0l31;
+	logset:hasPart :c0_0c1s11a0l32;
+	logset:hasPart :c0_0c1s11a0l33;
+	logset:hasPart :c0_0c1s11a0l34;
+	logset:hasPart :c0_0c1s11a0l35;
+	logset:hasPart :c0_0c1s11a0l36;
+	logset:hasPart :c0_0c1s11a0l37;
+	logset:hasPart :c0_0c1s11a0l40;
+	logset:hasPart :c0_0c1s11a0l41;
+	logset:hasPart :c0_0c1s11a0l42;
+	logset:hasPart :c0_0c1s11a0l43;
+	logset:hasPart :c0_0c1s11a0l44;
+	logset:hasPart :c0_0c1s11a0l45;
+	logset:hasPart :c0_0c1s11a0l46;
+	logset:hasPart :c0_0c1s11a0l47;
+	logset:hasPart :c0_0c1s11a0l50;
+	logset:hasPart :c0_0c1s11a0l51;
+	logset:hasPart :c0_0c1s11a0l52;
+	logset:hasPart :c0_0c1s11a0l53;
+	logset:hasPart :c0_0c1s11a0l54;
+	logset:hasPart :c0_0c1s11a0l55;
+	logset:hasPart :c0_0c1s11a0l56;
+	logset:hasPart :c0_0c1s11a0l57;
+	logset:hasPart :c0_0c1s11a0n0;
+	logset:hasPart :c0_0c1s11a0n1;
+	logset:hasPart :c0_0c1s11a0n2;
+	logset:hasPart :c0_0c1s11a0n3;
+	.
+
+:c0_0c1s12a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s12a0l00;
+	logset:hasPart :c0_0c1s12a0l01;
+	logset:hasPart :c0_0c1s12a0l02;
+	logset:hasPart :c0_0c1s12a0l03;
+	logset:hasPart :c0_0c1s12a0l04;
+	logset:hasPart :c0_0c1s12a0l05;
+	logset:hasPart :c0_0c1s12a0l06;
+	logset:hasPart :c0_0c1s12a0l07;
+	logset:hasPart :c0_0c1s12a0l10;
+	logset:hasPart :c0_0c1s12a0l11;
+	logset:hasPart :c0_0c1s12a0l12;
+	logset:hasPart :c0_0c1s12a0l13;
+	logset:hasPart :c0_0c1s12a0l14;
+	logset:hasPart :c0_0c1s12a0l15;
+	logset:hasPart :c0_0c1s12a0l16;
+	logset:hasPart :c0_0c1s12a0l17;
+	logset:hasPart :c0_0c1s12a0l20;
+	logset:hasPart :c0_0c1s12a0l21;
+	logset:hasPart :c0_0c1s12a0l22;
+	logset:hasPart :c0_0c1s12a0l23;
+	logset:hasPart :c0_0c1s12a0l24;
+	logset:hasPart :c0_0c1s12a0l25;
+	logset:hasPart :c0_0c1s12a0l26;
+	logset:hasPart :c0_0c1s12a0l27;
+	logset:hasPart :c0_0c1s12a0l30;
+	logset:hasPart :c0_0c1s12a0l31;
+	logset:hasPart :c0_0c1s12a0l32;
+	logset:hasPart :c0_0c1s12a0l33;
+	logset:hasPart :c0_0c1s12a0l34;
+	logset:hasPart :c0_0c1s12a0l35;
+	logset:hasPart :c0_0c1s12a0l36;
+	logset:hasPart :c0_0c1s12a0l37;
+	logset:hasPart :c0_0c1s12a0l40;
+	logset:hasPart :c0_0c1s12a0l41;
+	logset:hasPart :c0_0c1s12a0l42;
+	logset:hasPart :c0_0c1s12a0l43;
+	logset:hasPart :c0_0c1s12a0l44;
+	logset:hasPart :c0_0c1s12a0l45;
+	logset:hasPart :c0_0c1s12a0l46;
+	logset:hasPart :c0_0c1s12a0l47;
+	logset:hasPart :c0_0c1s12a0l50;
+	logset:hasPart :c0_0c1s12a0l51;
+	logset:hasPart :c0_0c1s12a0l52;
+	logset:hasPart :c0_0c1s12a0l53;
+	logset:hasPart :c0_0c1s12a0l54;
+	logset:hasPart :c0_0c1s12a0l55;
+	logset:hasPart :c0_0c1s12a0l56;
+	logset:hasPart :c0_0c1s12a0l57;
+	logset:hasPart :c0_0c1s12a0n0;
+	logset:hasPart :c0_0c1s12a0n1;
+	logset:hasPart :c0_0c1s12a0n2;
+	logset:hasPart :c0_0c1s12a0n3;
+	.
+
+:c0_0c1s13a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s13a0l00;
+	logset:hasPart :c0_0c1s13a0l01;
+	logset:hasPart :c0_0c1s13a0l02;
+	logset:hasPart :c0_0c1s13a0l03;
+	logset:hasPart :c0_0c1s13a0l04;
+	logset:hasPart :c0_0c1s13a0l05;
+	logset:hasPart :c0_0c1s13a0l06;
+	logset:hasPart :c0_0c1s13a0l07;
+	logset:hasPart :c0_0c1s13a0l10;
+	logset:hasPart :c0_0c1s13a0l11;
+	logset:hasPart :c0_0c1s13a0l12;
+	logset:hasPart :c0_0c1s13a0l13;
+	logset:hasPart :c0_0c1s13a0l14;
+	logset:hasPart :c0_0c1s13a0l15;
+	logset:hasPart :c0_0c1s13a0l16;
+	logset:hasPart :c0_0c1s13a0l17;
+	logset:hasPart :c0_0c1s13a0l20;
+	logset:hasPart :c0_0c1s13a0l21;
+	logset:hasPart :c0_0c1s13a0l22;
+	logset:hasPart :c0_0c1s13a0l23;
+	logset:hasPart :c0_0c1s13a0l24;
+	logset:hasPart :c0_0c1s13a0l25;
+	logset:hasPart :c0_0c1s13a0l26;
+	logset:hasPart :c0_0c1s13a0l27;
+	logset:hasPart :c0_0c1s13a0l30;
+	logset:hasPart :c0_0c1s13a0l31;
+	logset:hasPart :c0_0c1s13a0l32;
+	logset:hasPart :c0_0c1s13a0l33;
+	logset:hasPart :c0_0c1s13a0l34;
+	logset:hasPart :c0_0c1s13a0l35;
+	logset:hasPart :c0_0c1s13a0l36;
+	logset:hasPart :c0_0c1s13a0l37;
+	logset:hasPart :c0_0c1s13a0l40;
+	logset:hasPart :c0_0c1s13a0l41;
+	logset:hasPart :c0_0c1s13a0l42;
+	logset:hasPart :c0_0c1s13a0l43;
+	logset:hasPart :c0_0c1s13a0l44;
+	logset:hasPart :c0_0c1s13a0l45;
+	logset:hasPart :c0_0c1s13a0l46;
+	logset:hasPart :c0_0c1s13a0l47;
+	logset:hasPart :c0_0c1s13a0l50;
+	logset:hasPart :c0_0c1s13a0l51;
+	logset:hasPart :c0_0c1s13a0l52;
+	logset:hasPart :c0_0c1s13a0l53;
+	logset:hasPart :c0_0c1s13a0l54;
+	logset:hasPart :c0_0c1s13a0l55;
+	logset:hasPart :c0_0c1s13a0l56;
+	logset:hasPart :c0_0c1s13a0l57;
+	logset:hasPart :c0_0c1s13a0n0;
+	logset:hasPart :c0_0c1s13a0n1;
+	logset:hasPart :c0_0c1s13a0n2;
+	logset:hasPart :c0_0c1s13a0n3;
+	.
+
+:c0_0c1s14a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s14a0l00;
+	logset:hasPart :c0_0c1s14a0l01;
+	logset:hasPart :c0_0c1s14a0l02;
+	logset:hasPart :c0_0c1s14a0l03;
+	logset:hasPart :c0_0c1s14a0l04;
+	logset:hasPart :c0_0c1s14a0l05;
+	logset:hasPart :c0_0c1s14a0l06;
+	logset:hasPart :c0_0c1s14a0l07;
+	logset:hasPart :c0_0c1s14a0l10;
+	logset:hasPart :c0_0c1s14a0l11;
+	logset:hasPart :c0_0c1s14a0l12;
+	logset:hasPart :c0_0c1s14a0l13;
+	logset:hasPart :c0_0c1s14a0l14;
+	logset:hasPart :c0_0c1s14a0l15;
+	logset:hasPart :c0_0c1s14a0l16;
+	logset:hasPart :c0_0c1s14a0l17;
+	logset:hasPart :c0_0c1s14a0l20;
+	logset:hasPart :c0_0c1s14a0l21;
+	logset:hasPart :c0_0c1s14a0l22;
+	logset:hasPart :c0_0c1s14a0l23;
+	logset:hasPart :c0_0c1s14a0l24;
+	logset:hasPart :c0_0c1s14a0l25;
+	logset:hasPart :c0_0c1s14a0l26;
+	logset:hasPart :c0_0c1s14a0l27;
+	logset:hasPart :c0_0c1s14a0l30;
+	logset:hasPart :c0_0c1s14a0l31;
+	logset:hasPart :c0_0c1s14a0l32;
+	logset:hasPart :c0_0c1s14a0l33;
+	logset:hasPart :c0_0c1s14a0l34;
+	logset:hasPart :c0_0c1s14a0l35;
+	logset:hasPart :c0_0c1s14a0l36;
+	logset:hasPart :c0_0c1s14a0l37;
+	logset:hasPart :c0_0c1s14a0l40;
+	logset:hasPart :c0_0c1s14a0l41;
+	logset:hasPart :c0_0c1s14a0l42;
+	logset:hasPart :c0_0c1s14a0l43;
+	logset:hasPart :c0_0c1s14a0l44;
+	logset:hasPart :c0_0c1s14a0l45;
+	logset:hasPart :c0_0c1s14a0l46;
+	logset:hasPart :c0_0c1s14a0l47;
+	logset:hasPart :c0_0c1s14a0l50;
+	logset:hasPart :c0_0c1s14a0l51;
+	logset:hasPart :c0_0c1s14a0l52;
+	logset:hasPart :c0_0c1s14a0l53;
+	logset:hasPart :c0_0c1s14a0l54;
+	logset:hasPart :c0_0c1s14a0l55;
+	logset:hasPart :c0_0c1s14a0l56;
+	logset:hasPart :c0_0c1s14a0l57;
+	logset:hasPart :c0_0c1s14a0n0;
+	logset:hasPart :c0_0c1s14a0n1;
+	logset:hasPart :c0_0c1s14a0n2;
+	logset:hasPart :c0_0c1s14a0n3;
+	.
+
+:c0_0c1s15a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s15a0l00;
+	logset:hasPart :c0_0c1s15a0l01;
+	logset:hasPart :c0_0c1s15a0l02;
+	logset:hasPart :c0_0c1s15a0l03;
+	logset:hasPart :c0_0c1s15a0l04;
+	logset:hasPart :c0_0c1s15a0l05;
+	logset:hasPart :c0_0c1s15a0l06;
+	logset:hasPart :c0_0c1s15a0l07;
+	logset:hasPart :c0_0c1s15a0l10;
+	logset:hasPart :c0_0c1s15a0l11;
+	logset:hasPart :c0_0c1s15a0l12;
+	logset:hasPart :c0_0c1s15a0l13;
+	logset:hasPart :c0_0c1s15a0l14;
+	logset:hasPart :c0_0c1s15a0l15;
+	logset:hasPart :c0_0c1s15a0l16;
+	logset:hasPart :c0_0c1s15a0l17;
+	logset:hasPart :c0_0c1s15a0l20;
+	logset:hasPart :c0_0c1s15a0l21;
+	logset:hasPart :c0_0c1s15a0l22;
+	logset:hasPart :c0_0c1s15a0l23;
+	logset:hasPart :c0_0c1s15a0l24;
+	logset:hasPart :c0_0c1s15a0l25;
+	logset:hasPart :c0_0c1s15a0l26;
+	logset:hasPart :c0_0c1s15a0l27;
+	logset:hasPart :c0_0c1s15a0l30;
+	logset:hasPart :c0_0c1s15a0l31;
+	logset:hasPart :c0_0c1s15a0l32;
+	logset:hasPart :c0_0c1s15a0l33;
+	logset:hasPart :c0_0c1s15a0l34;
+	logset:hasPart :c0_0c1s15a0l35;
+	logset:hasPart :c0_0c1s15a0l36;
+	logset:hasPart :c0_0c1s15a0l37;
+	logset:hasPart :c0_0c1s15a0l40;
+	logset:hasPart :c0_0c1s15a0l41;
+	logset:hasPart :c0_0c1s15a0l42;
+	logset:hasPart :c0_0c1s15a0l43;
+	logset:hasPart :c0_0c1s15a0l44;
+	logset:hasPart :c0_0c1s15a0l45;
+	logset:hasPart :c0_0c1s15a0l46;
+	logset:hasPart :c0_0c1s15a0l47;
+	logset:hasPart :c0_0c1s15a0l50;
+	logset:hasPart :c0_0c1s15a0l51;
+	logset:hasPart :c0_0c1s15a0l52;
+	logset:hasPart :c0_0c1s15a0l53;
+	logset:hasPart :c0_0c1s15a0l54;
+	logset:hasPart :c0_0c1s15a0l55;
+	logset:hasPart :c0_0c1s15a0l56;
+	logset:hasPart :c0_0c1s15a0l57;
+	logset:hasPart :c0_0c1s15a0n0;
+	logset:hasPart :c0_0c1s15a0n1;
+	logset:hasPart :c0_0c1s15a0n2;
+	logset:hasPart :c0_0c1s15a0n3;
+	.
+
+:c0_0c1s1a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s1a0l00;
+	logset:hasPart :c0_0c1s1a0l01;
+	logset:hasPart :c0_0c1s1a0l02;
+	logset:hasPart :c0_0c1s1a0l03;
+	logset:hasPart :c0_0c1s1a0l04;
+	logset:hasPart :c0_0c1s1a0l05;
+	logset:hasPart :c0_0c1s1a0l06;
+	logset:hasPart :c0_0c1s1a0l07;
+	logset:hasPart :c0_0c1s1a0l10;
+	logset:hasPart :c0_0c1s1a0l11;
+	logset:hasPart :c0_0c1s1a0l12;
+	logset:hasPart :c0_0c1s1a0l13;
+	logset:hasPart :c0_0c1s1a0l14;
+	logset:hasPart :c0_0c1s1a0l15;
+	logset:hasPart :c0_0c1s1a0l16;
+	logset:hasPart :c0_0c1s1a0l17;
+	logset:hasPart :c0_0c1s1a0l20;
+	logset:hasPart :c0_0c1s1a0l21;
+	logset:hasPart :c0_0c1s1a0l22;
+	logset:hasPart :c0_0c1s1a0l23;
+	logset:hasPart :c0_0c1s1a0l24;
+	logset:hasPart :c0_0c1s1a0l25;
+	logset:hasPart :c0_0c1s1a0l26;
+	logset:hasPart :c0_0c1s1a0l27;
+	logset:hasPart :c0_0c1s1a0l30;
+	logset:hasPart :c0_0c1s1a0l31;
+	logset:hasPart :c0_0c1s1a0l32;
+	logset:hasPart :c0_0c1s1a0l33;
+	logset:hasPart :c0_0c1s1a0l34;
+	logset:hasPart :c0_0c1s1a0l35;
+	logset:hasPart :c0_0c1s1a0l36;
+	logset:hasPart :c0_0c1s1a0l37;
+	logset:hasPart :c0_0c1s1a0l40;
+	logset:hasPart :c0_0c1s1a0l41;
+	logset:hasPart :c0_0c1s1a0l42;
+	logset:hasPart :c0_0c1s1a0l43;
+	logset:hasPart :c0_0c1s1a0l44;
+	logset:hasPart :c0_0c1s1a0l45;
+	logset:hasPart :c0_0c1s1a0l46;
+	logset:hasPart :c0_0c1s1a0l47;
+	logset:hasPart :c0_0c1s1a0l50;
+	logset:hasPart :c0_0c1s1a0l51;
+	logset:hasPart :c0_0c1s1a0l52;
+	logset:hasPart :c0_0c1s1a0l53;
+	logset:hasPart :c0_0c1s1a0l54;
+	logset:hasPart :c0_0c1s1a0l55;
+	logset:hasPart :c0_0c1s1a0l56;
+	logset:hasPart :c0_0c1s1a0l57;
+	logset:hasPart :c0_0c1s1a0n0;
+	logset:hasPart :c0_0c1s1a0n1;
+	logset:hasPart :c0_0c1s1a0n2;
+	logset:hasPart :c0_0c1s1a0n3;
+	.
+
+:c0_0c1s2a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s2a0l00;
+	logset:hasPart :c0_0c1s2a0l01;
+	logset:hasPart :c0_0c1s2a0l02;
+	logset:hasPart :c0_0c1s2a0l03;
+	logset:hasPart :c0_0c1s2a0l04;
+	logset:hasPart :c0_0c1s2a0l05;
+	logset:hasPart :c0_0c1s2a0l06;
+	logset:hasPart :c0_0c1s2a0l07;
+	logset:hasPart :c0_0c1s2a0l10;
+	logset:hasPart :c0_0c1s2a0l11;
+	logset:hasPart :c0_0c1s2a0l12;
+	logset:hasPart :c0_0c1s2a0l13;
+	logset:hasPart :c0_0c1s2a0l14;
+	logset:hasPart :c0_0c1s2a0l15;
+	logset:hasPart :c0_0c1s2a0l16;
+	logset:hasPart :c0_0c1s2a0l17;
+	logset:hasPart :c0_0c1s2a0l20;
+	logset:hasPart :c0_0c1s2a0l21;
+	logset:hasPart :c0_0c1s2a0l22;
+	logset:hasPart :c0_0c1s2a0l23;
+	logset:hasPart :c0_0c1s2a0l24;
+	logset:hasPart :c0_0c1s2a0l25;
+	logset:hasPart :c0_0c1s2a0l26;
+	logset:hasPart :c0_0c1s2a0l27;
+	logset:hasPart :c0_0c1s2a0l30;
+	logset:hasPart :c0_0c1s2a0l31;
+	logset:hasPart :c0_0c1s2a0l32;
+	logset:hasPart :c0_0c1s2a0l33;
+	logset:hasPart :c0_0c1s2a0l34;
+	logset:hasPart :c0_0c1s2a0l35;
+	logset:hasPart :c0_0c1s2a0l36;
+	logset:hasPart :c0_0c1s2a0l37;
+	logset:hasPart :c0_0c1s2a0l40;
+	logset:hasPart :c0_0c1s2a0l41;
+	logset:hasPart :c0_0c1s2a0l42;
+	logset:hasPart :c0_0c1s2a0l43;
+	logset:hasPart :c0_0c1s2a0l44;
+	logset:hasPart :c0_0c1s2a0l45;
+	logset:hasPart :c0_0c1s2a0l46;
+	logset:hasPart :c0_0c1s2a0l47;
+	logset:hasPart :c0_0c1s2a0l50;
+	logset:hasPart :c0_0c1s2a0l51;
+	logset:hasPart :c0_0c1s2a0l52;
+	logset:hasPart :c0_0c1s2a0l53;
+	logset:hasPart :c0_0c1s2a0l54;
+	logset:hasPart :c0_0c1s2a0l55;
+	logset:hasPart :c0_0c1s2a0l56;
+	logset:hasPart :c0_0c1s2a0l57;
+	logset:hasPart :c0_0c1s2a0n0;
+	logset:hasPart :c0_0c1s2a0n1;
+	logset:hasPart :c0_0c1s2a0n2;
+	logset:hasPart :c0_0c1s2a0n3;
+	.
+
+:c0_0c1s3a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s3a0l00;
+	logset:hasPart :c0_0c1s3a0l01;
+	logset:hasPart :c0_0c1s3a0l02;
+	logset:hasPart :c0_0c1s3a0l03;
+	logset:hasPart :c0_0c1s3a0l04;
+	logset:hasPart :c0_0c1s3a0l05;
+	logset:hasPart :c0_0c1s3a0l06;
+	logset:hasPart :c0_0c1s3a0l07;
+	logset:hasPart :c0_0c1s3a0l10;
+	logset:hasPart :c0_0c1s3a0l11;
+	logset:hasPart :c0_0c1s3a0l12;
+	logset:hasPart :c0_0c1s3a0l13;
+	logset:hasPart :c0_0c1s3a0l14;
+	logset:hasPart :c0_0c1s3a0l15;
+	logset:hasPart :c0_0c1s3a0l16;
+	logset:hasPart :c0_0c1s3a0l17;
+	logset:hasPart :c0_0c1s3a0l20;
+	logset:hasPart :c0_0c1s3a0l21;
+	logset:hasPart :c0_0c1s3a0l22;
+	logset:hasPart :c0_0c1s3a0l23;
+	logset:hasPart :c0_0c1s3a0l24;
+	logset:hasPart :c0_0c1s3a0l25;
+	logset:hasPart :c0_0c1s3a0l26;
+	logset:hasPart :c0_0c1s3a0l27;
+	logset:hasPart :c0_0c1s3a0l30;
+	logset:hasPart :c0_0c1s3a0l31;
+	logset:hasPart :c0_0c1s3a0l32;
+	logset:hasPart :c0_0c1s3a0l33;
+	logset:hasPart :c0_0c1s3a0l34;
+	logset:hasPart :c0_0c1s3a0l35;
+	logset:hasPart :c0_0c1s3a0l36;
+	logset:hasPart :c0_0c1s3a0l37;
+	logset:hasPart :c0_0c1s3a0l40;
+	logset:hasPart :c0_0c1s3a0l41;
+	logset:hasPart :c0_0c1s3a0l42;
+	logset:hasPart :c0_0c1s3a0l43;
+	logset:hasPart :c0_0c1s3a0l44;
+	logset:hasPart :c0_0c1s3a0l45;
+	logset:hasPart :c0_0c1s3a0l46;
+	logset:hasPart :c0_0c1s3a0l47;
+	logset:hasPart :c0_0c1s3a0l50;
+	logset:hasPart :c0_0c1s3a0l51;
+	logset:hasPart :c0_0c1s3a0l52;
+	logset:hasPart :c0_0c1s3a0l53;
+	logset:hasPart :c0_0c1s3a0l54;
+	logset:hasPart :c0_0c1s3a0l55;
+	logset:hasPart :c0_0c1s3a0l56;
+	logset:hasPart :c0_0c1s3a0l57;
+	logset:hasPart :c0_0c1s3a0n0;
+	logset:hasPart :c0_0c1s3a0n1;
+	logset:hasPart :c0_0c1s3a0n2;
+	logset:hasPart :c0_0c1s3a0n3;
+	.
+
+:c0_0c1s4a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s4a0l00;
+	logset:hasPart :c0_0c1s4a0l01;
+	logset:hasPart :c0_0c1s4a0l02;
+	logset:hasPart :c0_0c1s4a0l03;
+	logset:hasPart :c0_0c1s4a0l04;
+	logset:hasPart :c0_0c1s4a0l05;
+	logset:hasPart :c0_0c1s4a0l06;
+	logset:hasPart :c0_0c1s4a0l07;
+	logset:hasPart :c0_0c1s4a0l10;
+	logset:hasPart :c0_0c1s4a0l11;
+	logset:hasPart :c0_0c1s4a0l12;
+	logset:hasPart :c0_0c1s4a0l13;
+	logset:hasPart :c0_0c1s4a0l14;
+	logset:hasPart :c0_0c1s4a0l15;
+	logset:hasPart :c0_0c1s4a0l16;
+	logset:hasPart :c0_0c1s4a0l17;
+	logset:hasPart :c0_0c1s4a0l20;
+	logset:hasPart :c0_0c1s4a0l21;
+	logset:hasPart :c0_0c1s4a0l22;
+	logset:hasPart :c0_0c1s4a0l23;
+	logset:hasPart :c0_0c1s4a0l24;
+	logset:hasPart :c0_0c1s4a0l25;
+	logset:hasPart :c0_0c1s4a0l26;
+	logset:hasPart :c0_0c1s4a0l27;
+	logset:hasPart :c0_0c1s4a0l30;
+	logset:hasPart :c0_0c1s4a0l31;
+	logset:hasPart :c0_0c1s4a0l32;
+	logset:hasPart :c0_0c1s4a0l33;
+	logset:hasPart :c0_0c1s4a0l34;
+	logset:hasPart :c0_0c1s4a0l35;
+	logset:hasPart :c0_0c1s4a0l36;
+	logset:hasPart :c0_0c1s4a0l37;
+	logset:hasPart :c0_0c1s4a0l40;
+	logset:hasPart :c0_0c1s4a0l41;
+	logset:hasPart :c0_0c1s4a0l42;
+	logset:hasPart :c0_0c1s4a0l43;
+	logset:hasPart :c0_0c1s4a0l44;
+	logset:hasPart :c0_0c1s4a0l45;
+	logset:hasPart :c0_0c1s4a0l46;
+	logset:hasPart :c0_0c1s4a0l47;
+	logset:hasPart :c0_0c1s4a0l50;
+	logset:hasPart :c0_0c1s4a0l51;
+	logset:hasPart :c0_0c1s4a0l52;
+	logset:hasPart :c0_0c1s4a0l53;
+	logset:hasPart :c0_0c1s4a0l54;
+	logset:hasPart :c0_0c1s4a0l55;
+	logset:hasPart :c0_0c1s4a0l56;
+	logset:hasPart :c0_0c1s4a0l57;
+	logset:hasPart :c0_0c1s4a0n0;
+	logset:hasPart :c0_0c1s4a0n1;
+	logset:hasPart :c0_0c1s4a0n2;
+	logset:hasPart :c0_0c1s4a0n3;
+	.
+
+:c0_0c1s5a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s5a0l00;
+	logset:hasPart :c0_0c1s5a0l01;
+	logset:hasPart :c0_0c1s5a0l02;
+	logset:hasPart :c0_0c1s5a0l03;
+	logset:hasPart :c0_0c1s5a0l04;
+	logset:hasPart :c0_0c1s5a0l05;
+	logset:hasPart :c0_0c1s5a0l06;
+	logset:hasPart :c0_0c1s5a0l07;
+	logset:hasPart :c0_0c1s5a0l10;
+	logset:hasPart :c0_0c1s5a0l11;
+	logset:hasPart :c0_0c1s5a0l12;
+	logset:hasPart :c0_0c1s5a0l13;
+	logset:hasPart :c0_0c1s5a0l14;
+	logset:hasPart :c0_0c1s5a0l15;
+	logset:hasPart :c0_0c1s5a0l16;
+	logset:hasPart :c0_0c1s5a0l17;
+	logset:hasPart :c0_0c1s5a0l20;
+	logset:hasPart :c0_0c1s5a0l21;
+	logset:hasPart :c0_0c1s5a0l22;
+	logset:hasPart :c0_0c1s5a0l23;
+	logset:hasPart :c0_0c1s5a0l24;
+	logset:hasPart :c0_0c1s5a0l25;
+	logset:hasPart :c0_0c1s5a0l26;
+	logset:hasPart :c0_0c1s5a0l27;
+	logset:hasPart :c0_0c1s5a0l30;
+	logset:hasPart :c0_0c1s5a0l31;
+	logset:hasPart :c0_0c1s5a0l32;
+	logset:hasPart :c0_0c1s5a0l33;
+	logset:hasPart :c0_0c1s5a0l34;
+	logset:hasPart :c0_0c1s5a0l35;
+	logset:hasPart :c0_0c1s5a0l36;
+	logset:hasPart :c0_0c1s5a0l37;
+	logset:hasPart :c0_0c1s5a0l40;
+	logset:hasPart :c0_0c1s5a0l41;
+	logset:hasPart :c0_0c1s5a0l42;
+	logset:hasPart :c0_0c1s5a0l43;
+	logset:hasPart :c0_0c1s5a0l44;
+	logset:hasPart :c0_0c1s5a0l45;
+	logset:hasPart :c0_0c1s5a0l46;
+	logset:hasPart :c0_0c1s5a0l47;
+	logset:hasPart :c0_0c1s5a0l50;
+	logset:hasPart :c0_0c1s5a0l51;
+	logset:hasPart :c0_0c1s5a0l52;
+	logset:hasPart :c0_0c1s5a0l53;
+	logset:hasPart :c0_0c1s5a0l54;
+	logset:hasPart :c0_0c1s5a0l55;
+	logset:hasPart :c0_0c1s5a0l56;
+	logset:hasPart :c0_0c1s5a0l57;
+	logset:hasPart :c0_0c1s5a0n0;
+	logset:hasPart :c0_0c1s5a0n1;
+	logset:hasPart :c0_0c1s5a0n2;
+	logset:hasPart :c0_0c1s5a0n3;
+	.
+
+:c0_0c1s6a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s6a0l00;
+	logset:hasPart :c0_0c1s6a0l01;
+	logset:hasPart :c0_0c1s6a0l02;
+	logset:hasPart :c0_0c1s6a0l03;
+	logset:hasPart :c0_0c1s6a0l04;
+	logset:hasPart :c0_0c1s6a0l05;
+	logset:hasPart :c0_0c1s6a0l06;
+	logset:hasPart :c0_0c1s6a0l07;
+	logset:hasPart :c0_0c1s6a0l10;
+	logset:hasPart :c0_0c1s6a0l11;
+	logset:hasPart :c0_0c1s6a0l12;
+	logset:hasPart :c0_0c1s6a0l13;
+	logset:hasPart :c0_0c1s6a0l14;
+	logset:hasPart :c0_0c1s6a0l15;
+	logset:hasPart :c0_0c1s6a0l16;
+	logset:hasPart :c0_0c1s6a0l17;
+	logset:hasPart :c0_0c1s6a0l20;
+	logset:hasPart :c0_0c1s6a0l21;
+	logset:hasPart :c0_0c1s6a0l22;
+	logset:hasPart :c0_0c1s6a0l23;
+	logset:hasPart :c0_0c1s6a0l24;
+	logset:hasPart :c0_0c1s6a0l25;
+	logset:hasPart :c0_0c1s6a0l26;
+	logset:hasPart :c0_0c1s6a0l27;
+	logset:hasPart :c0_0c1s6a0l30;
+	logset:hasPart :c0_0c1s6a0l31;
+	logset:hasPart :c0_0c1s6a0l32;
+	logset:hasPart :c0_0c1s6a0l33;
+	logset:hasPart :c0_0c1s6a0l34;
+	logset:hasPart :c0_0c1s6a0l35;
+	logset:hasPart :c0_0c1s6a0l36;
+	logset:hasPart :c0_0c1s6a0l37;
+	logset:hasPart :c0_0c1s6a0l40;
+	logset:hasPart :c0_0c1s6a0l41;
+	logset:hasPart :c0_0c1s6a0l42;
+	logset:hasPart :c0_0c1s6a0l43;
+	logset:hasPart :c0_0c1s6a0l44;
+	logset:hasPart :c0_0c1s6a0l45;
+	logset:hasPart :c0_0c1s6a0l46;
+	logset:hasPart :c0_0c1s6a0l47;
+	logset:hasPart :c0_0c1s6a0l50;
+	logset:hasPart :c0_0c1s6a0l51;
+	logset:hasPart :c0_0c1s6a0l52;
+	logset:hasPart :c0_0c1s6a0l53;
+	logset:hasPart :c0_0c1s6a0l54;
+	logset:hasPart :c0_0c1s6a0l55;
+	logset:hasPart :c0_0c1s6a0l56;
+	logset:hasPart :c0_0c1s6a0l57;
+	logset:hasPart :c0_0c1s6a0n0;
+	logset:hasPart :c0_0c1s6a0n1;
+	logset:hasPart :c0_0c1s6a0n2;
+	logset:hasPart :c0_0c1s6a0n3;
+	.
+
+:c0_0c1s7a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s7a0l00;
+	logset:hasPart :c0_0c1s7a0l01;
+	logset:hasPart :c0_0c1s7a0l02;
+	logset:hasPart :c0_0c1s7a0l03;
+	logset:hasPart :c0_0c1s7a0l04;
+	logset:hasPart :c0_0c1s7a0l05;
+	logset:hasPart :c0_0c1s7a0l06;
+	logset:hasPart :c0_0c1s7a0l07;
+	logset:hasPart :c0_0c1s7a0l10;
+	logset:hasPart :c0_0c1s7a0l11;
+	logset:hasPart :c0_0c1s7a0l12;
+	logset:hasPart :c0_0c1s7a0l13;
+	logset:hasPart :c0_0c1s7a0l14;
+	logset:hasPart :c0_0c1s7a0l15;
+	logset:hasPart :c0_0c1s7a0l16;
+	logset:hasPart :c0_0c1s7a0l17;
+	logset:hasPart :c0_0c1s7a0l20;
+	logset:hasPart :c0_0c1s7a0l21;
+	logset:hasPart :c0_0c1s7a0l22;
+	logset:hasPart :c0_0c1s7a0l23;
+	logset:hasPart :c0_0c1s7a0l24;
+	logset:hasPart :c0_0c1s7a0l25;
+	logset:hasPart :c0_0c1s7a0l26;
+	logset:hasPart :c0_0c1s7a0l27;
+	logset:hasPart :c0_0c1s7a0l30;
+	logset:hasPart :c0_0c1s7a0l31;
+	logset:hasPart :c0_0c1s7a0l32;
+	logset:hasPart :c0_0c1s7a0l33;
+	logset:hasPart :c0_0c1s7a0l34;
+	logset:hasPart :c0_0c1s7a0l35;
+	logset:hasPart :c0_0c1s7a0l36;
+	logset:hasPart :c0_0c1s7a0l37;
+	logset:hasPart :c0_0c1s7a0l40;
+	logset:hasPart :c0_0c1s7a0l41;
+	logset:hasPart :c0_0c1s7a0l42;
+	logset:hasPart :c0_0c1s7a0l43;
+	logset:hasPart :c0_0c1s7a0l44;
+	logset:hasPart :c0_0c1s7a0l45;
+	logset:hasPart :c0_0c1s7a0l46;
+	logset:hasPart :c0_0c1s7a0l47;
+	logset:hasPart :c0_0c1s7a0l50;
+	logset:hasPart :c0_0c1s7a0l51;
+	logset:hasPart :c0_0c1s7a0l52;
+	logset:hasPart :c0_0c1s7a0l53;
+	logset:hasPart :c0_0c1s7a0l54;
+	logset:hasPart :c0_0c1s7a0l55;
+	logset:hasPart :c0_0c1s7a0l56;
+	logset:hasPart :c0_0c1s7a0l57;
+	logset:hasPart :c0_0c1s7a0n0;
+	logset:hasPart :c0_0c1s7a0n1;
+	logset:hasPart :c0_0c1s7a0n2;
+	logset:hasPart :c0_0c1s7a0n3;
+	.
+
+:c0_0c1s8a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s8a0l00;
+	logset:hasPart :c0_0c1s8a0l01;
+	logset:hasPart :c0_0c1s8a0l02;
+	logset:hasPart :c0_0c1s8a0l03;
+	logset:hasPart :c0_0c1s8a0l04;
+	logset:hasPart :c0_0c1s8a0l05;
+	logset:hasPart :c0_0c1s8a0l06;
+	logset:hasPart :c0_0c1s8a0l07;
+	logset:hasPart :c0_0c1s8a0l10;
+	logset:hasPart :c0_0c1s8a0l11;
+	logset:hasPart :c0_0c1s8a0l12;
+	logset:hasPart :c0_0c1s8a0l13;
+	logset:hasPart :c0_0c1s8a0l14;
+	logset:hasPart :c0_0c1s8a0l15;
+	logset:hasPart :c0_0c1s8a0l16;
+	logset:hasPart :c0_0c1s8a0l17;
+	logset:hasPart :c0_0c1s8a0l20;
+	logset:hasPart :c0_0c1s8a0l21;
+	logset:hasPart :c0_0c1s8a0l22;
+	logset:hasPart :c0_0c1s8a0l23;
+	logset:hasPart :c0_0c1s8a0l24;
+	logset:hasPart :c0_0c1s8a0l25;
+	logset:hasPart :c0_0c1s8a0l26;
+	logset:hasPart :c0_0c1s8a0l27;
+	logset:hasPart :c0_0c1s8a0l30;
+	logset:hasPart :c0_0c1s8a0l31;
+	logset:hasPart :c0_0c1s8a0l32;
+	logset:hasPart :c0_0c1s8a0l33;
+	logset:hasPart :c0_0c1s8a0l34;
+	logset:hasPart :c0_0c1s8a0l35;
+	logset:hasPart :c0_0c1s8a0l36;
+	logset:hasPart :c0_0c1s8a0l37;
+	logset:hasPart :c0_0c1s8a0l40;
+	logset:hasPart :c0_0c1s8a0l41;
+	logset:hasPart :c0_0c1s8a0l42;
+	logset:hasPart :c0_0c1s8a0l43;
+	logset:hasPart :c0_0c1s8a0l44;
+	logset:hasPart :c0_0c1s8a0l45;
+	logset:hasPart :c0_0c1s8a0l46;
+	logset:hasPart :c0_0c1s8a0l47;
+	logset:hasPart :c0_0c1s8a0l50;
+	logset:hasPart :c0_0c1s8a0l51;
+	logset:hasPart :c0_0c1s8a0l52;
+	logset:hasPart :c0_0c1s8a0l53;
+	logset:hasPart :c0_0c1s8a0l54;
+	logset:hasPart :c0_0c1s8a0l55;
+	logset:hasPart :c0_0c1s8a0l56;
+	logset:hasPart :c0_0c1s8a0l57;
+	logset:hasPart :c0_0c1s8a0n0;
+	logset:hasPart :c0_0c1s8a0n1;
+	logset:hasPart :c0_0c1s8a0n2;
+	logset:hasPart :c0_0c1s8a0n3;
+	.
+
+:c0_0c1s9a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c1s9a0l00;
+	logset:hasPart :c0_0c1s9a0l01;
+	logset:hasPart :c0_0c1s9a0l02;
+	logset:hasPart :c0_0c1s9a0l03;
+	logset:hasPart :c0_0c1s9a0l04;
+	logset:hasPart :c0_0c1s9a0l05;
+	logset:hasPart :c0_0c1s9a0l06;
+	logset:hasPart :c0_0c1s9a0l07;
+	logset:hasPart :c0_0c1s9a0l10;
+	logset:hasPart :c0_0c1s9a0l11;
+	logset:hasPart :c0_0c1s9a0l12;
+	logset:hasPart :c0_0c1s9a0l13;
+	logset:hasPart :c0_0c1s9a0l14;
+	logset:hasPart :c0_0c1s9a0l15;
+	logset:hasPart :c0_0c1s9a0l16;
+	logset:hasPart :c0_0c1s9a0l17;
+	logset:hasPart :c0_0c1s9a0l20;
+	logset:hasPart :c0_0c1s9a0l21;
+	logset:hasPart :c0_0c1s9a0l22;
+	logset:hasPart :c0_0c1s9a0l23;
+	logset:hasPart :c0_0c1s9a0l24;
+	logset:hasPart :c0_0c1s9a0l25;
+	logset:hasPart :c0_0c1s9a0l26;
+	logset:hasPart :c0_0c1s9a0l27;
+	logset:hasPart :c0_0c1s9a0l30;
+	logset:hasPart :c0_0c1s9a0l31;
+	logset:hasPart :c0_0c1s9a0l32;
+	logset:hasPart :c0_0c1s9a0l33;
+	logset:hasPart :c0_0c1s9a0l34;
+	logset:hasPart :c0_0c1s9a0l35;
+	logset:hasPart :c0_0c1s9a0l36;
+	logset:hasPart :c0_0c1s9a0l37;
+	logset:hasPart :c0_0c1s9a0l40;
+	logset:hasPart :c0_0c1s9a0l41;
+	logset:hasPart :c0_0c1s9a0l42;
+	logset:hasPart :c0_0c1s9a0l43;
+	logset:hasPart :c0_0c1s9a0l44;
+	logset:hasPart :c0_0c1s9a0l45;
+	logset:hasPart :c0_0c1s9a0l46;
+	logset:hasPart :c0_0c1s9a0l47;
+	logset:hasPart :c0_0c1s9a0l50;
+	logset:hasPart :c0_0c1s9a0l51;
+	logset:hasPart :c0_0c1s9a0l52;
+	logset:hasPart :c0_0c1s9a0l53;
+	logset:hasPart :c0_0c1s9a0l54;
+	logset:hasPart :c0_0c1s9a0l55;
+	logset:hasPart :c0_0c1s9a0l56;
+	logset:hasPart :c0_0c1s9a0l57;
+	logset:hasPart :c0_0c1s9a0n0;
+	logset:hasPart :c0_0c1s9a0n1;
+	logset:hasPart :c0_0c1s9a0n2;
+	logset:hasPart :c0_0c1s9a0n3;
+	.
+
+:c0_0c2s0a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s0a0l00;
+	logset:hasPart :c0_0c2s0a0l01;
+	logset:hasPart :c0_0c2s0a0l02;
+	logset:hasPart :c0_0c2s0a0l03;
+	logset:hasPart :c0_0c2s0a0l04;
+	logset:hasPart :c0_0c2s0a0l05;
+	logset:hasPart :c0_0c2s0a0l06;
+	logset:hasPart :c0_0c2s0a0l07;
+	logset:hasPart :c0_0c2s0a0l10;
+	logset:hasPart :c0_0c2s0a0l11;
+	logset:hasPart :c0_0c2s0a0l12;
+	logset:hasPart :c0_0c2s0a0l13;
+	logset:hasPart :c0_0c2s0a0l14;
+	logset:hasPart :c0_0c2s0a0l15;
+	logset:hasPart :c0_0c2s0a0l16;
+	logset:hasPart :c0_0c2s0a0l17;
+	logset:hasPart :c0_0c2s0a0l20;
+	logset:hasPart :c0_0c2s0a0l21;
+	logset:hasPart :c0_0c2s0a0l22;
+	logset:hasPart :c0_0c2s0a0l23;
+	logset:hasPart :c0_0c2s0a0l24;
+	logset:hasPart :c0_0c2s0a0l25;
+	logset:hasPart :c0_0c2s0a0l26;
+	logset:hasPart :c0_0c2s0a0l27;
+	logset:hasPart :c0_0c2s0a0l30;
+	logset:hasPart :c0_0c2s0a0l31;
+	logset:hasPart :c0_0c2s0a0l32;
+	logset:hasPart :c0_0c2s0a0l33;
+	logset:hasPart :c0_0c2s0a0l34;
+	logset:hasPart :c0_0c2s0a0l35;
+	logset:hasPart :c0_0c2s0a0l36;
+	logset:hasPart :c0_0c2s0a0l37;
+	logset:hasPart :c0_0c2s0a0l40;
+	logset:hasPart :c0_0c2s0a0l41;
+	logset:hasPart :c0_0c2s0a0l42;
+	logset:hasPart :c0_0c2s0a0l43;
+	logset:hasPart :c0_0c2s0a0l44;
+	logset:hasPart :c0_0c2s0a0l45;
+	logset:hasPart :c0_0c2s0a0l46;
+	logset:hasPart :c0_0c2s0a0l47;
+	logset:hasPart :c0_0c2s0a0l50;
+	logset:hasPart :c0_0c2s0a0l51;
+	logset:hasPart :c0_0c2s0a0l52;
+	logset:hasPart :c0_0c2s0a0l53;
+	logset:hasPart :c0_0c2s0a0l54;
+	logset:hasPart :c0_0c2s0a0l55;
+	logset:hasPart :c0_0c2s0a0l56;
+	logset:hasPart :c0_0c2s0a0l57;
+	logset:hasPart :c0_0c2s0a0n0;
+	logset:hasPart :c0_0c2s0a0n1;
+	logset:hasPart :c0_0c2s0a0n2;
+	logset:hasPart :c0_0c2s0a0n3;
+	.
+
+:c0_0c2s10a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s10a0l00;
+	logset:hasPart :c0_0c2s10a0l01;
+	logset:hasPart :c0_0c2s10a0l02;
+	logset:hasPart :c0_0c2s10a0l03;
+	logset:hasPart :c0_0c2s10a0l04;
+	logset:hasPart :c0_0c2s10a0l05;
+	logset:hasPart :c0_0c2s10a0l06;
+	logset:hasPart :c0_0c2s10a0l07;
+	logset:hasPart :c0_0c2s10a0l10;
+	logset:hasPart :c0_0c2s10a0l11;
+	logset:hasPart :c0_0c2s10a0l12;
+	logset:hasPart :c0_0c2s10a0l13;
+	logset:hasPart :c0_0c2s10a0l14;
+	logset:hasPart :c0_0c2s10a0l15;
+	logset:hasPart :c0_0c2s10a0l16;
+	logset:hasPart :c0_0c2s10a0l17;
+	logset:hasPart :c0_0c2s10a0l20;
+	logset:hasPart :c0_0c2s10a0l21;
+	logset:hasPart :c0_0c2s10a0l22;
+	logset:hasPart :c0_0c2s10a0l23;
+	logset:hasPart :c0_0c2s10a0l24;
+	logset:hasPart :c0_0c2s10a0l25;
+	logset:hasPart :c0_0c2s10a0l26;
+	logset:hasPart :c0_0c2s10a0l27;
+	logset:hasPart :c0_0c2s10a0l30;
+	logset:hasPart :c0_0c2s10a0l31;
+	logset:hasPart :c0_0c2s10a0l32;
+	logset:hasPart :c0_0c2s10a0l33;
+	logset:hasPart :c0_0c2s10a0l34;
+	logset:hasPart :c0_0c2s10a0l35;
+	logset:hasPart :c0_0c2s10a0l36;
+	logset:hasPart :c0_0c2s10a0l37;
+	logset:hasPart :c0_0c2s10a0l40;
+	logset:hasPart :c0_0c2s10a0l41;
+	logset:hasPart :c0_0c2s10a0l42;
+	logset:hasPart :c0_0c2s10a0l43;
+	logset:hasPart :c0_0c2s10a0l44;
+	logset:hasPart :c0_0c2s10a0l45;
+	logset:hasPart :c0_0c2s10a0l46;
+	logset:hasPart :c0_0c2s10a0l47;
+	logset:hasPart :c0_0c2s10a0l50;
+	logset:hasPart :c0_0c2s10a0l51;
+	logset:hasPart :c0_0c2s10a0l52;
+	logset:hasPart :c0_0c2s10a0l53;
+	logset:hasPart :c0_0c2s10a0l54;
+	logset:hasPart :c0_0c2s10a0l55;
+	logset:hasPart :c0_0c2s10a0l56;
+	logset:hasPart :c0_0c2s10a0l57;
+	logset:hasPart :c0_0c2s10a0n0;
+	logset:hasPart :c0_0c2s10a0n1;
+	logset:hasPart :c0_0c2s10a0n2;
+	logset:hasPart :c0_0c2s10a0n3;
+	.
+
+:c0_0c2s11a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s11a0l00;
+	logset:hasPart :c0_0c2s11a0l01;
+	logset:hasPart :c0_0c2s11a0l02;
+	logset:hasPart :c0_0c2s11a0l03;
+	logset:hasPart :c0_0c2s11a0l04;
+	logset:hasPart :c0_0c2s11a0l05;
+	logset:hasPart :c0_0c2s11a0l06;
+	logset:hasPart :c0_0c2s11a0l07;
+	logset:hasPart :c0_0c2s11a0l10;
+	logset:hasPart :c0_0c2s11a0l11;
+	logset:hasPart :c0_0c2s11a0l12;
+	logset:hasPart :c0_0c2s11a0l13;
+	logset:hasPart :c0_0c2s11a0l14;
+	logset:hasPart :c0_0c2s11a0l15;
+	logset:hasPart :c0_0c2s11a0l16;
+	logset:hasPart :c0_0c2s11a0l17;
+	logset:hasPart :c0_0c2s11a0l20;
+	logset:hasPart :c0_0c2s11a0l21;
+	logset:hasPart :c0_0c2s11a0l22;
+	logset:hasPart :c0_0c2s11a0l23;
+	logset:hasPart :c0_0c2s11a0l24;
+	logset:hasPart :c0_0c2s11a0l25;
+	logset:hasPart :c0_0c2s11a0l26;
+	logset:hasPart :c0_0c2s11a0l27;
+	logset:hasPart :c0_0c2s11a0l30;
+	logset:hasPart :c0_0c2s11a0l31;
+	logset:hasPart :c0_0c2s11a0l32;
+	logset:hasPart :c0_0c2s11a0l33;
+	logset:hasPart :c0_0c2s11a0l34;
+	logset:hasPart :c0_0c2s11a0l35;
+	logset:hasPart :c0_0c2s11a0l36;
+	logset:hasPart :c0_0c2s11a0l37;
+	logset:hasPart :c0_0c2s11a0l40;
+	logset:hasPart :c0_0c2s11a0l41;
+	logset:hasPart :c0_0c2s11a0l42;
+	logset:hasPart :c0_0c2s11a0l43;
+	logset:hasPart :c0_0c2s11a0l44;
+	logset:hasPart :c0_0c2s11a0l45;
+	logset:hasPart :c0_0c2s11a0l46;
+	logset:hasPart :c0_0c2s11a0l47;
+	logset:hasPart :c0_0c2s11a0l50;
+	logset:hasPart :c0_0c2s11a0l51;
+	logset:hasPart :c0_0c2s11a0l52;
+	logset:hasPart :c0_0c2s11a0l53;
+	logset:hasPart :c0_0c2s11a0l54;
+	logset:hasPart :c0_0c2s11a0l55;
+	logset:hasPart :c0_0c2s11a0l56;
+	logset:hasPart :c0_0c2s11a0l57;
+	logset:hasPart :c0_0c2s11a0n0;
+	logset:hasPart :c0_0c2s11a0n1;
+	logset:hasPart :c0_0c2s11a0n2;
+	logset:hasPart :c0_0c2s11a0n3;
+	.
+
+:c0_0c2s12a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s12a0l00;
+	logset:hasPart :c0_0c2s12a0l01;
+	logset:hasPart :c0_0c2s12a0l02;
+	logset:hasPart :c0_0c2s12a0l03;
+	logset:hasPart :c0_0c2s12a0l04;
+	logset:hasPart :c0_0c2s12a0l05;
+	logset:hasPart :c0_0c2s12a0l06;
+	logset:hasPart :c0_0c2s12a0l07;
+	logset:hasPart :c0_0c2s12a0l10;
+	logset:hasPart :c0_0c2s12a0l11;
+	logset:hasPart :c0_0c2s12a0l12;
+	logset:hasPart :c0_0c2s12a0l13;
+	logset:hasPart :c0_0c2s12a0l14;
+	logset:hasPart :c0_0c2s12a0l15;
+	logset:hasPart :c0_0c2s12a0l16;
+	logset:hasPart :c0_0c2s12a0l17;
+	logset:hasPart :c0_0c2s12a0l20;
+	logset:hasPart :c0_0c2s12a0l21;
+	logset:hasPart :c0_0c2s12a0l22;
+	logset:hasPart :c0_0c2s12a0l23;
+	logset:hasPart :c0_0c2s12a0l24;
+	logset:hasPart :c0_0c2s12a0l25;
+	logset:hasPart :c0_0c2s12a0l26;
+	logset:hasPart :c0_0c2s12a0l27;
+	logset:hasPart :c0_0c2s12a0l30;
+	logset:hasPart :c0_0c2s12a0l31;
+	logset:hasPart :c0_0c2s12a0l32;
+	logset:hasPart :c0_0c2s12a0l33;
+	logset:hasPart :c0_0c2s12a0l34;
+	logset:hasPart :c0_0c2s12a0l35;
+	logset:hasPart :c0_0c2s12a0l36;
+	logset:hasPart :c0_0c2s12a0l37;
+	logset:hasPart :c0_0c2s12a0l40;
+	logset:hasPart :c0_0c2s12a0l41;
+	logset:hasPart :c0_0c2s12a0l42;
+	logset:hasPart :c0_0c2s12a0l43;
+	logset:hasPart :c0_0c2s12a0l44;
+	logset:hasPart :c0_0c2s12a0l45;
+	logset:hasPart :c0_0c2s12a0l46;
+	logset:hasPart :c0_0c2s12a0l47;
+	logset:hasPart :c0_0c2s12a0l50;
+	logset:hasPart :c0_0c2s12a0l51;
+	logset:hasPart :c0_0c2s12a0l52;
+	logset:hasPart :c0_0c2s12a0l53;
+	logset:hasPart :c0_0c2s12a0l54;
+	logset:hasPart :c0_0c2s12a0l55;
+	logset:hasPart :c0_0c2s12a0l56;
+	logset:hasPart :c0_0c2s12a0l57;
+	logset:hasPart :c0_0c2s12a0n0;
+	logset:hasPart :c0_0c2s12a0n1;
+	logset:hasPart :c0_0c2s12a0n2;
+	logset:hasPart :c0_0c2s12a0n3;
+	.
+
+:c0_0c2s1a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s1a0l00;
+	logset:hasPart :c0_0c2s1a0l01;
+	logset:hasPart :c0_0c2s1a0l02;
+	logset:hasPart :c0_0c2s1a0l03;
+	logset:hasPart :c0_0c2s1a0l04;
+	logset:hasPart :c0_0c2s1a0l05;
+	logset:hasPart :c0_0c2s1a0l06;
+	logset:hasPart :c0_0c2s1a0l07;
+	logset:hasPart :c0_0c2s1a0l10;
+	logset:hasPart :c0_0c2s1a0l11;
+	logset:hasPart :c0_0c2s1a0l12;
+	logset:hasPart :c0_0c2s1a0l13;
+	logset:hasPart :c0_0c2s1a0l14;
+	logset:hasPart :c0_0c2s1a0l15;
+	logset:hasPart :c0_0c2s1a0l16;
+	logset:hasPart :c0_0c2s1a0l17;
+	logset:hasPart :c0_0c2s1a0l20;
+	logset:hasPart :c0_0c2s1a0l21;
+	logset:hasPart :c0_0c2s1a0l22;
+	logset:hasPart :c0_0c2s1a0l23;
+	logset:hasPart :c0_0c2s1a0l24;
+	logset:hasPart :c0_0c2s1a0l25;
+	logset:hasPart :c0_0c2s1a0l26;
+	logset:hasPart :c0_0c2s1a0l27;
+	logset:hasPart :c0_0c2s1a0l30;
+	logset:hasPart :c0_0c2s1a0l31;
+	logset:hasPart :c0_0c2s1a0l32;
+	logset:hasPart :c0_0c2s1a0l33;
+	logset:hasPart :c0_0c2s1a0l34;
+	logset:hasPart :c0_0c2s1a0l35;
+	logset:hasPart :c0_0c2s1a0l36;
+	logset:hasPart :c0_0c2s1a0l37;
+	logset:hasPart :c0_0c2s1a0l40;
+	logset:hasPart :c0_0c2s1a0l41;
+	logset:hasPart :c0_0c2s1a0l42;
+	logset:hasPart :c0_0c2s1a0l43;
+	logset:hasPart :c0_0c2s1a0l44;
+	logset:hasPart :c0_0c2s1a0l45;
+	logset:hasPart :c0_0c2s1a0l46;
+	logset:hasPart :c0_0c2s1a0l47;
+	logset:hasPart :c0_0c2s1a0l50;
+	logset:hasPart :c0_0c2s1a0l51;
+	logset:hasPart :c0_0c2s1a0l52;
+	logset:hasPart :c0_0c2s1a0l53;
+	logset:hasPart :c0_0c2s1a0l54;
+	logset:hasPart :c0_0c2s1a0l55;
+	logset:hasPart :c0_0c2s1a0l56;
+	logset:hasPart :c0_0c2s1a0l57;
+	logset:hasPart :c0_0c2s1a0n0;
+	logset:hasPart :c0_0c2s1a0n1;
+	logset:hasPart :c0_0c2s1a0n2;
+	logset:hasPart :c0_0c2s1a0n3;
+	.
+
+:c0_0c2s2a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s2a0l00;
+	logset:hasPart :c0_0c2s2a0l01;
+	logset:hasPart :c0_0c2s2a0l02;
+	logset:hasPart :c0_0c2s2a0l03;
+	logset:hasPart :c0_0c2s2a0l04;
+	logset:hasPart :c0_0c2s2a0l05;
+	logset:hasPart :c0_0c2s2a0l06;
+	logset:hasPart :c0_0c2s2a0l07;
+	logset:hasPart :c0_0c2s2a0l10;
+	logset:hasPart :c0_0c2s2a0l11;
+	logset:hasPart :c0_0c2s2a0l12;
+	logset:hasPart :c0_0c2s2a0l13;
+	logset:hasPart :c0_0c2s2a0l14;
+	logset:hasPart :c0_0c2s2a0l15;
+	logset:hasPart :c0_0c2s2a0l16;
+	logset:hasPart :c0_0c2s2a0l17;
+	logset:hasPart :c0_0c2s2a0l20;
+	logset:hasPart :c0_0c2s2a0l21;
+	logset:hasPart :c0_0c2s2a0l22;
+	logset:hasPart :c0_0c2s2a0l23;
+	logset:hasPart :c0_0c2s2a0l24;
+	logset:hasPart :c0_0c2s2a0l25;
+	logset:hasPart :c0_0c2s2a0l26;
+	logset:hasPart :c0_0c2s2a0l27;
+	logset:hasPart :c0_0c2s2a0l30;
+	logset:hasPart :c0_0c2s2a0l31;
+	logset:hasPart :c0_0c2s2a0l32;
+	logset:hasPart :c0_0c2s2a0l33;
+	logset:hasPart :c0_0c2s2a0l34;
+	logset:hasPart :c0_0c2s2a0l35;
+	logset:hasPart :c0_0c2s2a0l36;
+	logset:hasPart :c0_0c2s2a0l37;
+	logset:hasPart :c0_0c2s2a0l40;
+	logset:hasPart :c0_0c2s2a0l41;
+	logset:hasPart :c0_0c2s2a0l42;
+	logset:hasPart :c0_0c2s2a0l43;
+	logset:hasPart :c0_0c2s2a0l44;
+	logset:hasPart :c0_0c2s2a0l45;
+	logset:hasPart :c0_0c2s2a0l46;
+	logset:hasPart :c0_0c2s2a0l47;
+	logset:hasPart :c0_0c2s2a0l50;
+	logset:hasPart :c0_0c2s2a0l51;
+	logset:hasPart :c0_0c2s2a0l52;
+	logset:hasPart :c0_0c2s2a0l53;
+	logset:hasPart :c0_0c2s2a0l54;
+	logset:hasPart :c0_0c2s2a0l55;
+	logset:hasPart :c0_0c2s2a0l56;
+	logset:hasPart :c0_0c2s2a0l57;
+	logset:hasPart :c0_0c2s2a0n0;
+	logset:hasPart :c0_0c2s2a0n1;
+	logset:hasPart :c0_0c2s2a0n2;
+	logset:hasPart :c0_0c2s2a0n3;
+	.
+
+:c0_0c2s3a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s3a0l00;
+	logset:hasPart :c0_0c2s3a0l01;
+	logset:hasPart :c0_0c2s3a0l02;
+	logset:hasPart :c0_0c2s3a0l03;
+	logset:hasPart :c0_0c2s3a0l04;
+	logset:hasPart :c0_0c2s3a0l05;
+	logset:hasPart :c0_0c2s3a0l06;
+	logset:hasPart :c0_0c2s3a0l07;
+	logset:hasPart :c0_0c2s3a0l10;
+	logset:hasPart :c0_0c2s3a0l11;
+	logset:hasPart :c0_0c2s3a0l12;
+	logset:hasPart :c0_0c2s3a0l13;
+	logset:hasPart :c0_0c2s3a0l14;
+	logset:hasPart :c0_0c2s3a0l15;
+	logset:hasPart :c0_0c2s3a0l16;
+	logset:hasPart :c0_0c2s3a0l17;
+	logset:hasPart :c0_0c2s3a0l20;
+	logset:hasPart :c0_0c2s3a0l21;
+	logset:hasPart :c0_0c2s3a0l22;
+	logset:hasPart :c0_0c2s3a0l23;
+	logset:hasPart :c0_0c2s3a0l24;
+	logset:hasPart :c0_0c2s3a0l25;
+	logset:hasPart :c0_0c2s3a0l26;
+	logset:hasPart :c0_0c2s3a0l27;
+	logset:hasPart :c0_0c2s3a0l30;
+	logset:hasPart :c0_0c2s3a0l31;
+	logset:hasPart :c0_0c2s3a0l32;
+	logset:hasPart :c0_0c2s3a0l33;
+	logset:hasPart :c0_0c2s3a0l34;
+	logset:hasPart :c0_0c2s3a0l35;
+	logset:hasPart :c0_0c2s3a0l36;
+	logset:hasPart :c0_0c2s3a0l37;
+	logset:hasPart :c0_0c2s3a0l40;
+	logset:hasPart :c0_0c2s3a0l41;
+	logset:hasPart :c0_0c2s3a0l42;
+	logset:hasPart :c0_0c2s3a0l43;
+	logset:hasPart :c0_0c2s3a0l44;
+	logset:hasPart :c0_0c2s3a0l45;
+	logset:hasPart :c0_0c2s3a0l46;
+	logset:hasPart :c0_0c2s3a0l47;
+	logset:hasPart :c0_0c2s3a0l50;
+	logset:hasPart :c0_0c2s3a0l51;
+	logset:hasPart :c0_0c2s3a0l52;
+	logset:hasPart :c0_0c2s3a0l53;
+	logset:hasPart :c0_0c2s3a0l54;
+	logset:hasPart :c0_0c2s3a0l55;
+	logset:hasPart :c0_0c2s3a0l56;
+	logset:hasPart :c0_0c2s3a0l57;
+	logset:hasPart :c0_0c2s3a0n0;
+	logset:hasPart :c0_0c2s3a0n1;
+	logset:hasPart :c0_0c2s3a0n2;
+	logset:hasPart :c0_0c2s3a0n3;
+	.
+
+:c0_0c2s4a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s4a0l00;
+	logset:hasPart :c0_0c2s4a0l01;
+	logset:hasPart :c0_0c2s4a0l02;
+	logset:hasPart :c0_0c2s4a0l03;
+	logset:hasPart :c0_0c2s4a0l04;
+	logset:hasPart :c0_0c2s4a0l05;
+	logset:hasPart :c0_0c2s4a0l06;
+	logset:hasPart :c0_0c2s4a0l07;
+	logset:hasPart :c0_0c2s4a0l10;
+	logset:hasPart :c0_0c2s4a0l11;
+	logset:hasPart :c0_0c2s4a0l12;
+	logset:hasPart :c0_0c2s4a0l13;
+	logset:hasPart :c0_0c2s4a0l14;
+	logset:hasPart :c0_0c2s4a0l15;
+	logset:hasPart :c0_0c2s4a0l16;
+	logset:hasPart :c0_0c2s4a0l17;
+	logset:hasPart :c0_0c2s4a0l20;
+	logset:hasPart :c0_0c2s4a0l21;
+	logset:hasPart :c0_0c2s4a0l22;
+	logset:hasPart :c0_0c2s4a0l23;
+	logset:hasPart :c0_0c2s4a0l24;
+	logset:hasPart :c0_0c2s4a0l25;
+	logset:hasPart :c0_0c2s4a0l26;
+	logset:hasPart :c0_0c2s4a0l27;
+	logset:hasPart :c0_0c2s4a0l30;
+	logset:hasPart :c0_0c2s4a0l31;
+	logset:hasPart :c0_0c2s4a0l32;
+	logset:hasPart :c0_0c2s4a0l33;
+	logset:hasPart :c0_0c2s4a0l34;
+	logset:hasPart :c0_0c2s4a0l35;
+	logset:hasPart :c0_0c2s4a0l36;
+	logset:hasPart :c0_0c2s4a0l37;
+	logset:hasPart :c0_0c2s4a0l40;
+	logset:hasPart :c0_0c2s4a0l41;
+	logset:hasPart :c0_0c2s4a0l42;
+	logset:hasPart :c0_0c2s4a0l43;
+	logset:hasPart :c0_0c2s4a0l44;
+	logset:hasPart :c0_0c2s4a0l45;
+	logset:hasPart :c0_0c2s4a0l46;
+	logset:hasPart :c0_0c2s4a0l47;
+	logset:hasPart :c0_0c2s4a0l50;
+	logset:hasPart :c0_0c2s4a0l51;
+	logset:hasPart :c0_0c2s4a0l52;
+	logset:hasPart :c0_0c2s4a0l53;
+	logset:hasPart :c0_0c2s4a0l54;
+	logset:hasPart :c0_0c2s4a0l55;
+	logset:hasPart :c0_0c2s4a0l56;
+	logset:hasPart :c0_0c2s4a0l57;
+	logset:hasPart :c0_0c2s4a0n0;
+	logset:hasPart :c0_0c2s4a0n1;
+	logset:hasPart :c0_0c2s4a0n2;
+	logset:hasPart :c0_0c2s4a0n3;
+	.
+
+:c0_0c2s8a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s8a0l00;
+	logset:hasPart :c0_0c2s8a0l01;
+	logset:hasPart :c0_0c2s8a0l02;
+	logset:hasPart :c0_0c2s8a0l03;
+	logset:hasPart :c0_0c2s8a0l04;
+	logset:hasPart :c0_0c2s8a0l05;
+	logset:hasPart :c0_0c2s8a0l06;
+	logset:hasPart :c0_0c2s8a0l07;
+	logset:hasPart :c0_0c2s8a0l10;
+	logset:hasPart :c0_0c2s8a0l11;
+	logset:hasPart :c0_0c2s8a0l12;
+	logset:hasPart :c0_0c2s8a0l13;
+	logset:hasPart :c0_0c2s8a0l14;
+	logset:hasPart :c0_0c2s8a0l15;
+	logset:hasPart :c0_0c2s8a0l16;
+	logset:hasPart :c0_0c2s8a0l17;
+	logset:hasPart :c0_0c2s8a0l20;
+	logset:hasPart :c0_0c2s8a0l21;
+	logset:hasPart :c0_0c2s8a0l22;
+	logset:hasPart :c0_0c2s8a0l23;
+	logset:hasPart :c0_0c2s8a0l24;
+	logset:hasPart :c0_0c2s8a0l25;
+	logset:hasPart :c0_0c2s8a0l26;
+	logset:hasPart :c0_0c2s8a0l27;
+	logset:hasPart :c0_0c2s8a0l30;
+	logset:hasPart :c0_0c2s8a0l31;
+	logset:hasPart :c0_0c2s8a0l32;
+	logset:hasPart :c0_0c2s8a0l33;
+	logset:hasPart :c0_0c2s8a0l34;
+	logset:hasPart :c0_0c2s8a0l35;
+	logset:hasPart :c0_0c2s8a0l36;
+	logset:hasPart :c0_0c2s8a0l37;
+	logset:hasPart :c0_0c2s8a0l40;
+	logset:hasPart :c0_0c2s8a0l41;
+	logset:hasPart :c0_0c2s8a0l42;
+	logset:hasPart :c0_0c2s8a0l43;
+	logset:hasPart :c0_0c2s8a0l44;
+	logset:hasPart :c0_0c2s8a0l45;
+	logset:hasPart :c0_0c2s8a0l46;
+	logset:hasPart :c0_0c2s8a0l47;
+	logset:hasPart :c0_0c2s8a0l50;
+	logset:hasPart :c0_0c2s8a0l51;
+	logset:hasPart :c0_0c2s8a0l52;
+	logset:hasPart :c0_0c2s8a0l53;
+	logset:hasPart :c0_0c2s8a0l54;
+	logset:hasPart :c0_0c2s8a0l55;
+	logset:hasPart :c0_0c2s8a0l56;
+	logset:hasPart :c0_0c2s8a0l57;
+	logset:hasPart :c0_0c2s8a0n0;
+	logset:hasPart :c0_0c2s8a0n1;
+	logset:hasPart :c0_0c2s8a0n2;
+	logset:hasPart :c0_0c2s8a0n3;
+	.
+
+:c0_0c2s9a0 a craydict:AriesRouter ;
+	logset:hasPart :c0_0c2s9a0l00;
+	logset:hasPart :c0_0c2s9a0l01;
+	logset:hasPart :c0_0c2s9a0l02;
+	logset:hasPart :c0_0c2s9a0l03;
+	logset:hasPart :c0_0c2s9a0l04;
+	logset:hasPart :c0_0c2s9a0l05;
+	logset:hasPart :c0_0c2s9a0l06;
+	logset:hasPart :c0_0c2s9a0l07;
+	logset:hasPart :c0_0c2s9a0l10;
+	logset:hasPart :c0_0c2s9a0l11;
+	logset:hasPart :c0_0c2s9a0l12;
+	logset:hasPart :c0_0c2s9a0l13;
+	logset:hasPart :c0_0c2s9a0l14;
+	logset:hasPart :c0_0c2s9a0l15;
+	logset:hasPart :c0_0c2s9a0l16;
+	logset:hasPart :c0_0c2s9a0l17;
+	logset:hasPart :c0_0c2s9a0l20;
+	logset:hasPart :c0_0c2s9a0l21;
+	logset:hasPart :c0_0c2s9a0l22;
+	logset:hasPart :c0_0c2s9a0l23;
+	logset:hasPart :c0_0c2s9a0l24;
+	logset:hasPart :c0_0c2s9a0l25;
+	logset:hasPart :c0_0c2s9a0l26;
+	logset:hasPart :c0_0c2s9a0l27;
+	logset:hasPart :c0_0c2s9a0l30;
+	logset:hasPart :c0_0c2s9a0l31;
+	logset:hasPart :c0_0c2s9a0l32;
+	logset:hasPart :c0_0c2s9a0l33;
+	logset:hasPart :c0_0c2s9a0l34;
+	logset:hasPart :c0_0c2s9a0l35;
+	logset:hasPart :c0_0c2s9a0l36;
+	logset:hasPart :c0_0c2s9a0l37;
+	logset:hasPart :c0_0c2s9a0l40;
+	logset:hasPart :c0_0c2s9a0l41;
+	logset:hasPart :c0_0c2s9a0l42;
+	logset:hasPart :c0_0c2s9a0l43;
+	logset:hasPart :c0_0c2s9a0l44;
+	logset:hasPart :c0_0c2s9a0l45;
+	logset:hasPart :c0_0c2s9a0l46;
+	logset:hasPart :c0_0c2s9a0l47;
+	logset:hasPart :c0_0c2s9a0l50;
+	logset:hasPart :c0_0c2s9a0l51;
+	logset:hasPart :c0_0c2s9a0l52;
+	logset:hasPart :c0_0c2s9a0l53;
+	logset:hasPart :c0_0c2s9a0l54;
+	logset:hasPart :c0_0c2s9a0l55;
+	logset:hasPart :c0_0c2s9a0l56;
+	logset:hasPart :c0_0c2s9a0l57;
+	logset:hasPart :c0_0c2s9a0n0;
+	logset:hasPart :c0_0c2s9a0n1;
+	logset:hasPart :c0_0c2s9a0n2;
+	logset:hasPart :c0_0c2s9a0n3;
+	.
+
+:c1_0c0s0a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s0a0l00;
+	logset:hasPart :c1_0c0s0a0l01;
+	logset:hasPart :c1_0c0s0a0l02;
+	logset:hasPart :c1_0c0s0a0l03;
+	logset:hasPart :c1_0c0s0a0l04;
+	logset:hasPart :c1_0c0s0a0l05;
+	logset:hasPart :c1_0c0s0a0l06;
+	logset:hasPart :c1_0c0s0a0l07;
+	logset:hasPart :c1_0c0s0a0l10;
+	logset:hasPart :c1_0c0s0a0l11;
+	logset:hasPart :c1_0c0s0a0l12;
+	logset:hasPart :c1_0c0s0a0l13;
+	logset:hasPart :c1_0c0s0a0l14;
+	logset:hasPart :c1_0c0s0a0l15;
+	logset:hasPart :c1_0c0s0a0l16;
+	logset:hasPart :c1_0c0s0a0l17;
+	logset:hasPart :c1_0c0s0a0l20;
+	logset:hasPart :c1_0c0s0a0l21;
+	logset:hasPart :c1_0c0s0a0l22;
+	logset:hasPart :c1_0c0s0a0l23;
+	logset:hasPart :c1_0c0s0a0l24;
+	logset:hasPart :c1_0c0s0a0l25;
+	logset:hasPart :c1_0c0s0a0l26;
+	logset:hasPart :c1_0c0s0a0l27;
+	logset:hasPart :c1_0c0s0a0l30;
+	logset:hasPart :c1_0c0s0a0l31;
+	logset:hasPart :c1_0c0s0a0l32;
+	logset:hasPart :c1_0c0s0a0l33;
+	logset:hasPart :c1_0c0s0a0l34;
+	logset:hasPart :c1_0c0s0a0l35;
+	logset:hasPart :c1_0c0s0a0l36;
+	logset:hasPart :c1_0c0s0a0l37;
+	logset:hasPart :c1_0c0s0a0l40;
+	logset:hasPart :c1_0c0s0a0l41;
+	logset:hasPart :c1_0c0s0a0l42;
+	logset:hasPart :c1_0c0s0a0l43;
+	logset:hasPart :c1_0c0s0a0l44;
+	logset:hasPart :c1_0c0s0a0l45;
+	logset:hasPart :c1_0c0s0a0l46;
+	logset:hasPart :c1_0c0s0a0l47;
+	logset:hasPart :c1_0c0s0a0l50;
+	logset:hasPart :c1_0c0s0a0l51;
+	logset:hasPart :c1_0c0s0a0l52;
+	logset:hasPart :c1_0c0s0a0l53;
+	logset:hasPart :c1_0c0s0a0l54;
+	logset:hasPart :c1_0c0s0a0l55;
+	logset:hasPart :c1_0c0s0a0l56;
+	logset:hasPart :c1_0c0s0a0l57;
+	logset:hasPart :c1_0c0s0a0n0;
+	logset:hasPart :c1_0c0s0a0n1;
+	logset:hasPart :c1_0c0s0a0n2;
+	logset:hasPart :c1_0c0s0a0n3;
+	.
+
+:c1_0c0s10a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s10a0l00;
+	logset:hasPart :c1_0c0s10a0l01;
+	logset:hasPart :c1_0c0s10a0l02;
+	logset:hasPart :c1_0c0s10a0l03;
+	logset:hasPart :c1_0c0s10a0l04;
+	logset:hasPart :c1_0c0s10a0l05;
+	logset:hasPart :c1_0c0s10a0l06;
+	logset:hasPart :c1_0c0s10a0l07;
+	logset:hasPart :c1_0c0s10a0l10;
+	logset:hasPart :c1_0c0s10a0l11;
+	logset:hasPart :c1_0c0s10a0l12;
+	logset:hasPart :c1_0c0s10a0l13;
+	logset:hasPart :c1_0c0s10a0l14;
+	logset:hasPart :c1_0c0s10a0l15;
+	logset:hasPart :c1_0c0s10a0l16;
+	logset:hasPart :c1_0c0s10a0l17;
+	logset:hasPart :c1_0c0s10a0l20;
+	logset:hasPart :c1_0c0s10a0l21;
+	logset:hasPart :c1_0c0s10a0l22;
+	logset:hasPart :c1_0c0s10a0l23;
+	logset:hasPart :c1_0c0s10a0l24;
+	logset:hasPart :c1_0c0s10a0l25;
+	logset:hasPart :c1_0c0s10a0l26;
+	logset:hasPart :c1_0c0s10a0l27;
+	logset:hasPart :c1_0c0s10a0l30;
+	logset:hasPart :c1_0c0s10a0l31;
+	logset:hasPart :c1_0c0s10a0l32;
+	logset:hasPart :c1_0c0s10a0l33;
+	logset:hasPart :c1_0c0s10a0l34;
+	logset:hasPart :c1_0c0s10a0l35;
+	logset:hasPart :c1_0c0s10a0l36;
+	logset:hasPart :c1_0c0s10a0l37;
+	logset:hasPart :c1_0c0s10a0l40;
+	logset:hasPart :c1_0c0s10a0l41;
+	logset:hasPart :c1_0c0s10a0l42;
+	logset:hasPart :c1_0c0s10a0l43;
+	logset:hasPart :c1_0c0s10a0l44;
+	logset:hasPart :c1_0c0s10a0l45;
+	logset:hasPart :c1_0c0s10a0l46;
+	logset:hasPart :c1_0c0s10a0l47;
+	logset:hasPart :c1_0c0s10a0l50;
+	logset:hasPart :c1_0c0s10a0l51;
+	logset:hasPart :c1_0c0s10a0l52;
+	logset:hasPart :c1_0c0s10a0l53;
+	logset:hasPart :c1_0c0s10a0l54;
+	logset:hasPart :c1_0c0s10a0l55;
+	logset:hasPart :c1_0c0s10a0l56;
+	logset:hasPart :c1_0c0s10a0l57;
+	logset:hasPart :c1_0c0s10a0n0;
+	logset:hasPart :c1_0c0s10a0n1;
+	logset:hasPart :c1_0c0s10a0n2;
+	logset:hasPart :c1_0c0s10a0n3;
+	.
+
+:c1_0c0s11a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s11a0l00;
+	logset:hasPart :c1_0c0s11a0l01;
+	logset:hasPart :c1_0c0s11a0l02;
+	logset:hasPart :c1_0c0s11a0l03;
+	logset:hasPart :c1_0c0s11a0l04;
+	logset:hasPart :c1_0c0s11a0l05;
+	logset:hasPart :c1_0c0s11a0l06;
+	logset:hasPart :c1_0c0s11a0l07;
+	logset:hasPart :c1_0c0s11a0l10;
+	logset:hasPart :c1_0c0s11a0l11;
+	logset:hasPart :c1_0c0s11a0l12;
+	logset:hasPart :c1_0c0s11a0l13;
+	logset:hasPart :c1_0c0s11a0l14;
+	logset:hasPart :c1_0c0s11a0l15;
+	logset:hasPart :c1_0c0s11a0l16;
+	logset:hasPart :c1_0c0s11a0l17;
+	logset:hasPart :c1_0c0s11a0l20;
+	logset:hasPart :c1_0c0s11a0l21;
+	logset:hasPart :c1_0c0s11a0l22;
+	logset:hasPart :c1_0c0s11a0l23;
+	logset:hasPart :c1_0c0s11a0l24;
+	logset:hasPart :c1_0c0s11a0l25;
+	logset:hasPart :c1_0c0s11a0l26;
+	logset:hasPart :c1_0c0s11a0l27;
+	logset:hasPart :c1_0c0s11a0l30;
+	logset:hasPart :c1_0c0s11a0l31;
+	logset:hasPart :c1_0c0s11a0l32;
+	logset:hasPart :c1_0c0s11a0l33;
+	logset:hasPart :c1_0c0s11a0l34;
+	logset:hasPart :c1_0c0s11a0l35;
+	logset:hasPart :c1_0c0s11a0l36;
+	logset:hasPart :c1_0c0s11a0l37;
+	logset:hasPart :c1_0c0s11a0l40;
+	logset:hasPart :c1_0c0s11a0l41;
+	logset:hasPart :c1_0c0s11a0l42;
+	logset:hasPart :c1_0c0s11a0l43;
+	logset:hasPart :c1_0c0s11a0l44;
+	logset:hasPart :c1_0c0s11a0l45;
+	logset:hasPart :c1_0c0s11a0l46;
+	logset:hasPart :c1_0c0s11a0l47;
+	logset:hasPart :c1_0c0s11a0l50;
+	logset:hasPart :c1_0c0s11a0l51;
+	logset:hasPart :c1_0c0s11a0l52;
+	logset:hasPart :c1_0c0s11a0l53;
+	logset:hasPart :c1_0c0s11a0l54;
+	logset:hasPart :c1_0c0s11a0l55;
+	logset:hasPart :c1_0c0s11a0l56;
+	logset:hasPart :c1_0c0s11a0l57;
+	logset:hasPart :c1_0c0s11a0n0;
+	logset:hasPart :c1_0c0s11a0n1;
+	logset:hasPart :c1_0c0s11a0n2;
+	logset:hasPart :c1_0c0s11a0n3;
+	.
+
+:c1_0c0s12a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s12a0l00;
+	logset:hasPart :c1_0c0s12a0l01;
+	logset:hasPart :c1_0c0s12a0l02;
+	logset:hasPart :c1_0c0s12a0l03;
+	logset:hasPart :c1_0c0s12a0l04;
+	logset:hasPart :c1_0c0s12a0l05;
+	logset:hasPart :c1_0c0s12a0l06;
+	logset:hasPart :c1_0c0s12a0l07;
+	logset:hasPart :c1_0c0s12a0l10;
+	logset:hasPart :c1_0c0s12a0l11;
+	logset:hasPart :c1_0c0s12a0l12;
+	logset:hasPart :c1_0c0s12a0l13;
+	logset:hasPart :c1_0c0s12a0l14;
+	logset:hasPart :c1_0c0s12a0l15;
+	logset:hasPart :c1_0c0s12a0l16;
+	logset:hasPart :c1_0c0s12a0l17;
+	logset:hasPart :c1_0c0s12a0l20;
+	logset:hasPart :c1_0c0s12a0l21;
+	logset:hasPart :c1_0c0s12a0l22;
+	logset:hasPart :c1_0c0s12a0l23;
+	logset:hasPart :c1_0c0s12a0l24;
+	logset:hasPart :c1_0c0s12a0l25;
+	logset:hasPart :c1_0c0s12a0l26;
+	logset:hasPart :c1_0c0s12a0l27;
+	logset:hasPart :c1_0c0s12a0l30;
+	logset:hasPart :c1_0c0s12a0l31;
+	logset:hasPart :c1_0c0s12a0l32;
+	logset:hasPart :c1_0c0s12a0l33;
+	logset:hasPart :c1_0c0s12a0l34;
+	logset:hasPart :c1_0c0s12a0l35;
+	logset:hasPart :c1_0c0s12a0l36;
+	logset:hasPart :c1_0c0s12a0l37;
+	logset:hasPart :c1_0c0s12a0l40;
+	logset:hasPart :c1_0c0s12a0l41;
+	logset:hasPart :c1_0c0s12a0l42;
+	logset:hasPart :c1_0c0s12a0l43;
+	logset:hasPart :c1_0c0s12a0l44;
+	logset:hasPart :c1_0c0s12a0l45;
+	logset:hasPart :c1_0c0s12a0l46;
+	logset:hasPart :c1_0c0s12a0l47;
+	logset:hasPart :c1_0c0s12a0l50;
+	logset:hasPart :c1_0c0s12a0l51;
+	logset:hasPart :c1_0c0s12a0l52;
+	logset:hasPart :c1_0c0s12a0l53;
+	logset:hasPart :c1_0c0s12a0l54;
+	logset:hasPart :c1_0c0s12a0l55;
+	logset:hasPart :c1_0c0s12a0l56;
+	logset:hasPart :c1_0c0s12a0l57;
+	logset:hasPart :c1_0c0s12a0n0;
+	logset:hasPart :c1_0c0s12a0n1;
+	logset:hasPart :c1_0c0s12a0n2;
+	logset:hasPart :c1_0c0s12a0n3;
+	.
+
+:c1_0c0s13a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s13a0l00;
+	logset:hasPart :c1_0c0s13a0l01;
+	logset:hasPart :c1_0c0s13a0l02;
+	logset:hasPart :c1_0c0s13a0l03;
+	logset:hasPart :c1_0c0s13a0l04;
+	logset:hasPart :c1_0c0s13a0l05;
+	logset:hasPart :c1_0c0s13a0l06;
+	logset:hasPart :c1_0c0s13a0l07;
+	logset:hasPart :c1_0c0s13a0l10;
+	logset:hasPart :c1_0c0s13a0l11;
+	logset:hasPart :c1_0c0s13a0l12;
+	logset:hasPart :c1_0c0s13a0l13;
+	logset:hasPart :c1_0c0s13a0l14;
+	logset:hasPart :c1_0c0s13a0l15;
+	logset:hasPart :c1_0c0s13a0l16;
+	logset:hasPart :c1_0c0s13a0l17;
+	logset:hasPart :c1_0c0s13a0l20;
+	logset:hasPart :c1_0c0s13a0l21;
+	logset:hasPart :c1_0c0s13a0l22;
+	logset:hasPart :c1_0c0s13a0l23;
+	logset:hasPart :c1_0c0s13a0l24;
+	logset:hasPart :c1_0c0s13a0l25;
+	logset:hasPart :c1_0c0s13a0l26;
+	logset:hasPart :c1_0c0s13a0l27;
+	logset:hasPart :c1_0c0s13a0l30;
+	logset:hasPart :c1_0c0s13a0l31;
+	logset:hasPart :c1_0c0s13a0l32;
+	logset:hasPart :c1_0c0s13a0l33;
+	logset:hasPart :c1_0c0s13a0l34;
+	logset:hasPart :c1_0c0s13a0l35;
+	logset:hasPart :c1_0c0s13a0l36;
+	logset:hasPart :c1_0c0s13a0l37;
+	logset:hasPart :c1_0c0s13a0l40;
+	logset:hasPart :c1_0c0s13a0l41;
+	logset:hasPart :c1_0c0s13a0l42;
+	logset:hasPart :c1_0c0s13a0l43;
+	logset:hasPart :c1_0c0s13a0l44;
+	logset:hasPart :c1_0c0s13a0l45;
+	logset:hasPart :c1_0c0s13a0l46;
+	logset:hasPart :c1_0c0s13a0l47;
+	logset:hasPart :c1_0c0s13a0l50;
+	logset:hasPart :c1_0c0s13a0l51;
+	logset:hasPart :c1_0c0s13a0l52;
+	logset:hasPart :c1_0c0s13a0l53;
+	logset:hasPart :c1_0c0s13a0l54;
+	logset:hasPart :c1_0c0s13a0l55;
+	logset:hasPart :c1_0c0s13a0l56;
+	logset:hasPart :c1_0c0s13a0l57;
+	logset:hasPart :c1_0c0s13a0n0;
+	logset:hasPart :c1_0c0s13a0n1;
+	logset:hasPart :c1_0c0s13a0n2;
+	logset:hasPart :c1_0c0s13a0n3;
+	.
+
+:c1_0c0s14a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s14a0l00;
+	logset:hasPart :c1_0c0s14a0l01;
+	logset:hasPart :c1_0c0s14a0l02;
+	logset:hasPart :c1_0c0s14a0l03;
+	logset:hasPart :c1_0c0s14a0l04;
+	logset:hasPart :c1_0c0s14a0l05;
+	logset:hasPart :c1_0c0s14a0l06;
+	logset:hasPart :c1_0c0s14a0l07;
+	logset:hasPart :c1_0c0s14a0l10;
+	logset:hasPart :c1_0c0s14a0l11;
+	logset:hasPart :c1_0c0s14a0l12;
+	logset:hasPart :c1_0c0s14a0l13;
+	logset:hasPart :c1_0c0s14a0l14;
+	logset:hasPart :c1_0c0s14a0l15;
+	logset:hasPart :c1_0c0s14a0l16;
+	logset:hasPart :c1_0c0s14a0l17;
+	logset:hasPart :c1_0c0s14a0l20;
+	logset:hasPart :c1_0c0s14a0l21;
+	logset:hasPart :c1_0c0s14a0l22;
+	logset:hasPart :c1_0c0s14a0l23;
+	logset:hasPart :c1_0c0s14a0l24;
+	logset:hasPart :c1_0c0s14a0l25;
+	logset:hasPart :c1_0c0s14a0l26;
+	logset:hasPart :c1_0c0s14a0l27;
+	logset:hasPart :c1_0c0s14a0l30;
+	logset:hasPart :c1_0c0s14a0l31;
+	logset:hasPart :c1_0c0s14a0l32;
+	logset:hasPart :c1_0c0s14a0l33;
+	logset:hasPart :c1_0c0s14a0l34;
+	logset:hasPart :c1_0c0s14a0l35;
+	logset:hasPart :c1_0c0s14a0l36;
+	logset:hasPart :c1_0c0s14a0l37;
+	logset:hasPart :c1_0c0s14a0l40;
+	logset:hasPart :c1_0c0s14a0l41;
+	logset:hasPart :c1_0c0s14a0l42;
+	logset:hasPart :c1_0c0s14a0l43;
+	logset:hasPart :c1_0c0s14a0l44;
+	logset:hasPart :c1_0c0s14a0l45;
+	logset:hasPart :c1_0c0s14a0l46;
+	logset:hasPart :c1_0c0s14a0l47;
+	logset:hasPart :c1_0c0s14a0l50;
+	logset:hasPart :c1_0c0s14a0l51;
+	logset:hasPart :c1_0c0s14a0l52;
+	logset:hasPart :c1_0c0s14a0l53;
+	logset:hasPart :c1_0c0s14a0l54;
+	logset:hasPart :c1_0c0s14a0l55;
+	logset:hasPart :c1_0c0s14a0l56;
+	logset:hasPart :c1_0c0s14a0l57;
+	logset:hasPart :c1_0c0s14a0n0;
+	logset:hasPart :c1_0c0s14a0n1;
+	logset:hasPart :c1_0c0s14a0n2;
+	logset:hasPart :c1_0c0s14a0n3;
+	.
+
+:c1_0c0s15a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s15a0l00;
+	logset:hasPart :c1_0c0s15a0l01;
+	logset:hasPart :c1_0c0s15a0l02;
+	logset:hasPart :c1_0c0s15a0l03;
+	logset:hasPart :c1_0c0s15a0l04;
+	logset:hasPart :c1_0c0s15a0l05;
+	logset:hasPart :c1_0c0s15a0l06;
+	logset:hasPart :c1_0c0s15a0l07;
+	logset:hasPart :c1_0c0s15a0l10;
+	logset:hasPart :c1_0c0s15a0l11;
+	logset:hasPart :c1_0c0s15a0l12;
+	logset:hasPart :c1_0c0s15a0l13;
+	logset:hasPart :c1_0c0s15a0l14;
+	logset:hasPart :c1_0c0s15a0l15;
+	logset:hasPart :c1_0c0s15a0l16;
+	logset:hasPart :c1_0c0s15a0l17;
+	logset:hasPart :c1_0c0s15a0l20;
+	logset:hasPart :c1_0c0s15a0l21;
+	logset:hasPart :c1_0c0s15a0l22;
+	logset:hasPart :c1_0c0s15a0l23;
+	logset:hasPart :c1_0c0s15a0l24;
+	logset:hasPart :c1_0c0s15a0l25;
+	logset:hasPart :c1_0c0s15a0l26;
+	logset:hasPart :c1_0c0s15a0l27;
+	logset:hasPart :c1_0c0s15a0l30;
+	logset:hasPart :c1_0c0s15a0l31;
+	logset:hasPart :c1_0c0s15a0l32;
+	logset:hasPart :c1_0c0s15a0l33;
+	logset:hasPart :c1_0c0s15a0l34;
+	logset:hasPart :c1_0c0s15a0l35;
+	logset:hasPart :c1_0c0s15a0l36;
+	logset:hasPart :c1_0c0s15a0l37;
+	logset:hasPart :c1_0c0s15a0l40;
+	logset:hasPart :c1_0c0s15a0l41;
+	logset:hasPart :c1_0c0s15a0l42;
+	logset:hasPart :c1_0c0s15a0l43;
+	logset:hasPart :c1_0c0s15a0l44;
+	logset:hasPart :c1_0c0s15a0l45;
+	logset:hasPart :c1_0c0s15a0l46;
+	logset:hasPart :c1_0c0s15a0l47;
+	logset:hasPart :c1_0c0s15a0l50;
+	logset:hasPart :c1_0c0s15a0l51;
+	logset:hasPart :c1_0c0s15a0l52;
+	logset:hasPart :c1_0c0s15a0l53;
+	logset:hasPart :c1_0c0s15a0l54;
+	logset:hasPart :c1_0c0s15a0l55;
+	logset:hasPart :c1_0c0s15a0l56;
+	logset:hasPart :c1_0c0s15a0l57;
+	logset:hasPart :c1_0c0s15a0n0;
+	logset:hasPart :c1_0c0s15a0n1;
+	logset:hasPart :c1_0c0s15a0n2;
+	logset:hasPart :c1_0c0s15a0n3;
+	.
+
+:c1_0c0s1a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s1a0l00;
+	logset:hasPart :c1_0c0s1a0l01;
+	logset:hasPart :c1_0c0s1a0l02;
+	logset:hasPart :c1_0c0s1a0l03;
+	logset:hasPart :c1_0c0s1a0l04;
+	logset:hasPart :c1_0c0s1a0l05;
+	logset:hasPart :c1_0c0s1a0l06;
+	logset:hasPart :c1_0c0s1a0l07;
+	logset:hasPart :c1_0c0s1a0l10;
+	logset:hasPart :c1_0c0s1a0l11;
+	logset:hasPart :c1_0c0s1a0l12;
+	logset:hasPart :c1_0c0s1a0l13;
+	logset:hasPart :c1_0c0s1a0l14;
+	logset:hasPart :c1_0c0s1a0l15;
+	logset:hasPart :c1_0c0s1a0l16;
+	logset:hasPart :c1_0c0s1a0l17;
+	logset:hasPart :c1_0c0s1a0l20;
+	logset:hasPart :c1_0c0s1a0l21;
+	logset:hasPart :c1_0c0s1a0l22;
+	logset:hasPart :c1_0c0s1a0l23;
+	logset:hasPart :c1_0c0s1a0l24;
+	logset:hasPart :c1_0c0s1a0l25;
+	logset:hasPart :c1_0c0s1a0l26;
+	logset:hasPart :c1_0c0s1a0l27;
+	logset:hasPart :c1_0c0s1a0l30;
+	logset:hasPart :c1_0c0s1a0l31;
+	logset:hasPart :c1_0c0s1a0l32;
+	logset:hasPart :c1_0c0s1a0l33;
+	logset:hasPart :c1_0c0s1a0l34;
+	logset:hasPart :c1_0c0s1a0l35;
+	logset:hasPart :c1_0c0s1a0l36;
+	logset:hasPart :c1_0c0s1a0l37;
+	logset:hasPart :c1_0c0s1a0l40;
+	logset:hasPart :c1_0c0s1a0l41;
+	logset:hasPart :c1_0c0s1a0l42;
+	logset:hasPart :c1_0c0s1a0l43;
+	logset:hasPart :c1_0c0s1a0l44;
+	logset:hasPart :c1_0c0s1a0l45;
+	logset:hasPart :c1_0c0s1a0l46;
+	logset:hasPart :c1_0c0s1a0l47;
+	logset:hasPart :c1_0c0s1a0l50;
+	logset:hasPart :c1_0c0s1a0l51;
+	logset:hasPart :c1_0c0s1a0l52;
+	logset:hasPart :c1_0c0s1a0l53;
+	logset:hasPart :c1_0c0s1a0l54;
+	logset:hasPart :c1_0c0s1a0l55;
+	logset:hasPart :c1_0c0s1a0l56;
+	logset:hasPart :c1_0c0s1a0l57;
+	logset:hasPart :c1_0c0s1a0n0;
+	logset:hasPart :c1_0c0s1a0n1;
+	logset:hasPart :c1_0c0s1a0n2;
+	logset:hasPart :c1_0c0s1a0n3;
+	.
+
+:c1_0c0s2a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s2a0l00;
+	logset:hasPart :c1_0c0s2a0l01;
+	logset:hasPart :c1_0c0s2a0l02;
+	logset:hasPart :c1_0c0s2a0l03;
+	logset:hasPart :c1_0c0s2a0l04;
+	logset:hasPart :c1_0c0s2a0l05;
+	logset:hasPart :c1_0c0s2a0l06;
+	logset:hasPart :c1_0c0s2a0l07;
+	logset:hasPart :c1_0c0s2a0l10;
+	logset:hasPart :c1_0c0s2a0l11;
+	logset:hasPart :c1_0c0s2a0l12;
+	logset:hasPart :c1_0c0s2a0l13;
+	logset:hasPart :c1_0c0s2a0l14;
+	logset:hasPart :c1_0c0s2a0l15;
+	logset:hasPart :c1_0c0s2a0l16;
+	logset:hasPart :c1_0c0s2a0l17;
+	logset:hasPart :c1_0c0s2a0l20;
+	logset:hasPart :c1_0c0s2a0l21;
+	logset:hasPart :c1_0c0s2a0l22;
+	logset:hasPart :c1_0c0s2a0l23;
+	logset:hasPart :c1_0c0s2a0l24;
+	logset:hasPart :c1_0c0s2a0l25;
+	logset:hasPart :c1_0c0s2a0l26;
+	logset:hasPart :c1_0c0s2a0l27;
+	logset:hasPart :c1_0c0s2a0l30;
+	logset:hasPart :c1_0c0s2a0l31;
+	logset:hasPart :c1_0c0s2a0l32;
+	logset:hasPart :c1_0c0s2a0l33;
+	logset:hasPart :c1_0c0s2a0l34;
+	logset:hasPart :c1_0c0s2a0l35;
+	logset:hasPart :c1_0c0s2a0l36;
+	logset:hasPart :c1_0c0s2a0l37;
+	logset:hasPart :c1_0c0s2a0l40;
+	logset:hasPart :c1_0c0s2a0l41;
+	logset:hasPart :c1_0c0s2a0l42;
+	logset:hasPart :c1_0c0s2a0l43;
+	logset:hasPart :c1_0c0s2a0l44;
+	logset:hasPart :c1_0c0s2a0l45;
+	logset:hasPart :c1_0c0s2a0l46;
+	logset:hasPart :c1_0c0s2a0l47;
+	logset:hasPart :c1_0c0s2a0l50;
+	logset:hasPart :c1_0c0s2a0l51;
+	logset:hasPart :c1_0c0s2a0l52;
+	logset:hasPart :c1_0c0s2a0l53;
+	logset:hasPart :c1_0c0s2a0l54;
+	logset:hasPart :c1_0c0s2a0l55;
+	logset:hasPart :c1_0c0s2a0l56;
+	logset:hasPart :c1_0c0s2a0l57;
+	logset:hasPart :c1_0c0s2a0n0;
+	logset:hasPart :c1_0c0s2a0n1;
+	logset:hasPart :c1_0c0s2a0n2;
+	logset:hasPart :c1_0c0s2a0n3;
+	.
+
+:c1_0c0s3a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s3a0l00;
+	logset:hasPart :c1_0c0s3a0l01;
+	logset:hasPart :c1_0c0s3a0l02;
+	logset:hasPart :c1_0c0s3a0l03;
+	logset:hasPart :c1_0c0s3a0l04;
+	logset:hasPart :c1_0c0s3a0l05;
+	logset:hasPart :c1_0c0s3a0l06;
+	logset:hasPart :c1_0c0s3a0l07;
+	logset:hasPart :c1_0c0s3a0l10;
+	logset:hasPart :c1_0c0s3a0l11;
+	logset:hasPart :c1_0c0s3a0l12;
+	logset:hasPart :c1_0c0s3a0l13;
+	logset:hasPart :c1_0c0s3a0l14;
+	logset:hasPart :c1_0c0s3a0l15;
+	logset:hasPart :c1_0c0s3a0l16;
+	logset:hasPart :c1_0c0s3a0l17;
+	logset:hasPart :c1_0c0s3a0l20;
+	logset:hasPart :c1_0c0s3a0l21;
+	logset:hasPart :c1_0c0s3a0l22;
+	logset:hasPart :c1_0c0s3a0l23;
+	logset:hasPart :c1_0c0s3a0l24;
+	logset:hasPart :c1_0c0s3a0l25;
+	logset:hasPart :c1_0c0s3a0l26;
+	logset:hasPart :c1_0c0s3a0l27;
+	logset:hasPart :c1_0c0s3a0l30;
+	logset:hasPart :c1_0c0s3a0l31;
+	logset:hasPart :c1_0c0s3a0l32;
+	logset:hasPart :c1_0c0s3a0l33;
+	logset:hasPart :c1_0c0s3a0l34;
+	logset:hasPart :c1_0c0s3a0l35;
+	logset:hasPart :c1_0c0s3a0l36;
+	logset:hasPart :c1_0c0s3a0l37;
+	logset:hasPart :c1_0c0s3a0l40;
+	logset:hasPart :c1_0c0s3a0l41;
+	logset:hasPart :c1_0c0s3a0l42;
+	logset:hasPart :c1_0c0s3a0l43;
+	logset:hasPart :c1_0c0s3a0l44;
+	logset:hasPart :c1_0c0s3a0l45;
+	logset:hasPart :c1_0c0s3a0l46;
+	logset:hasPart :c1_0c0s3a0l47;
+	logset:hasPart :c1_0c0s3a0l50;
+	logset:hasPart :c1_0c0s3a0l51;
+	logset:hasPart :c1_0c0s3a0l52;
+	logset:hasPart :c1_0c0s3a0l53;
+	logset:hasPart :c1_0c0s3a0l54;
+	logset:hasPart :c1_0c0s3a0l55;
+	logset:hasPart :c1_0c0s3a0l56;
+	logset:hasPart :c1_0c0s3a0l57;
+	logset:hasPart :c1_0c0s3a0n0;
+	logset:hasPart :c1_0c0s3a0n1;
+	logset:hasPart :c1_0c0s3a0n2;
+	logset:hasPart :c1_0c0s3a0n3;
+	.
+
+:c1_0c0s4a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s4a0l00;
+	logset:hasPart :c1_0c0s4a0l01;
+	logset:hasPart :c1_0c0s4a0l02;
+	logset:hasPart :c1_0c0s4a0l03;
+	logset:hasPart :c1_0c0s4a0l04;
+	logset:hasPart :c1_0c0s4a0l05;
+	logset:hasPart :c1_0c0s4a0l06;
+	logset:hasPart :c1_0c0s4a0l07;
+	logset:hasPart :c1_0c0s4a0l10;
+	logset:hasPart :c1_0c0s4a0l11;
+	logset:hasPart :c1_0c0s4a0l12;
+	logset:hasPart :c1_0c0s4a0l13;
+	logset:hasPart :c1_0c0s4a0l14;
+	logset:hasPart :c1_0c0s4a0l15;
+	logset:hasPart :c1_0c0s4a0l16;
+	logset:hasPart :c1_0c0s4a0l17;
+	logset:hasPart :c1_0c0s4a0l20;
+	logset:hasPart :c1_0c0s4a0l21;
+	logset:hasPart :c1_0c0s4a0l22;
+	logset:hasPart :c1_0c0s4a0l23;
+	logset:hasPart :c1_0c0s4a0l24;
+	logset:hasPart :c1_0c0s4a0l25;
+	logset:hasPart :c1_0c0s4a0l26;
+	logset:hasPart :c1_0c0s4a0l27;
+	logset:hasPart :c1_0c0s4a0l30;
+	logset:hasPart :c1_0c0s4a0l31;
+	logset:hasPart :c1_0c0s4a0l32;
+	logset:hasPart :c1_0c0s4a0l33;
+	logset:hasPart :c1_0c0s4a0l34;
+	logset:hasPart :c1_0c0s4a0l35;
+	logset:hasPart :c1_0c0s4a0l36;
+	logset:hasPart :c1_0c0s4a0l37;
+	logset:hasPart :c1_0c0s4a0l40;
+	logset:hasPart :c1_0c0s4a0l41;
+	logset:hasPart :c1_0c0s4a0l42;
+	logset:hasPart :c1_0c0s4a0l43;
+	logset:hasPart :c1_0c0s4a0l44;
+	logset:hasPart :c1_0c0s4a0l45;
+	logset:hasPart :c1_0c0s4a0l46;
+	logset:hasPart :c1_0c0s4a0l47;
+	logset:hasPart :c1_0c0s4a0l50;
+	logset:hasPart :c1_0c0s4a0l51;
+	logset:hasPart :c1_0c0s4a0l52;
+	logset:hasPart :c1_0c0s4a0l53;
+	logset:hasPart :c1_0c0s4a0l54;
+	logset:hasPart :c1_0c0s4a0l55;
+	logset:hasPart :c1_0c0s4a0l56;
+	logset:hasPart :c1_0c0s4a0l57;
+	logset:hasPart :c1_0c0s4a0n0;
+	logset:hasPart :c1_0c0s4a0n1;
+	logset:hasPart :c1_0c0s4a0n2;
+	logset:hasPart :c1_0c0s4a0n3;
+	.
+
+:c1_0c0s5a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s5a0l00;
+	logset:hasPart :c1_0c0s5a0l01;
+	logset:hasPart :c1_0c0s5a0l02;
+	logset:hasPart :c1_0c0s5a0l03;
+	logset:hasPart :c1_0c0s5a0l04;
+	logset:hasPart :c1_0c0s5a0l05;
+	logset:hasPart :c1_0c0s5a0l06;
+	logset:hasPart :c1_0c0s5a0l07;
+	logset:hasPart :c1_0c0s5a0l10;
+	logset:hasPart :c1_0c0s5a0l11;
+	logset:hasPart :c1_0c0s5a0l12;
+	logset:hasPart :c1_0c0s5a0l13;
+	logset:hasPart :c1_0c0s5a0l14;
+	logset:hasPart :c1_0c0s5a0l15;
+	logset:hasPart :c1_0c0s5a0l16;
+	logset:hasPart :c1_0c0s5a0l17;
+	logset:hasPart :c1_0c0s5a0l20;
+	logset:hasPart :c1_0c0s5a0l21;
+	logset:hasPart :c1_0c0s5a0l22;
+	logset:hasPart :c1_0c0s5a0l23;
+	logset:hasPart :c1_0c0s5a0l24;
+	logset:hasPart :c1_0c0s5a0l25;
+	logset:hasPart :c1_0c0s5a0l26;
+	logset:hasPart :c1_0c0s5a0l27;
+	logset:hasPart :c1_0c0s5a0l30;
+	logset:hasPart :c1_0c0s5a0l31;
+	logset:hasPart :c1_0c0s5a0l32;
+	logset:hasPart :c1_0c0s5a0l33;
+	logset:hasPart :c1_0c0s5a0l34;
+	logset:hasPart :c1_0c0s5a0l35;
+	logset:hasPart :c1_0c0s5a0l36;
+	logset:hasPart :c1_0c0s5a0l37;
+	logset:hasPart :c1_0c0s5a0l40;
+	logset:hasPart :c1_0c0s5a0l41;
+	logset:hasPart :c1_0c0s5a0l42;
+	logset:hasPart :c1_0c0s5a0l43;
+	logset:hasPart :c1_0c0s5a0l44;
+	logset:hasPart :c1_0c0s5a0l45;
+	logset:hasPart :c1_0c0s5a0l46;
+	logset:hasPart :c1_0c0s5a0l47;
+	logset:hasPart :c1_0c0s5a0l50;
+	logset:hasPart :c1_0c0s5a0l51;
+	logset:hasPart :c1_0c0s5a0l52;
+	logset:hasPart :c1_0c0s5a0l53;
+	logset:hasPart :c1_0c0s5a0l54;
+	logset:hasPart :c1_0c0s5a0l55;
+	logset:hasPart :c1_0c0s5a0l56;
+	logset:hasPart :c1_0c0s5a0l57;
+	logset:hasPart :c1_0c0s5a0n0;
+	logset:hasPart :c1_0c0s5a0n1;
+	logset:hasPart :c1_0c0s5a0n2;
+	logset:hasPart :c1_0c0s5a0n3;
+	.
+
+:c1_0c0s6a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s6a0l00;
+	logset:hasPart :c1_0c0s6a0l01;
+	logset:hasPart :c1_0c0s6a0l02;
+	logset:hasPart :c1_0c0s6a0l03;
+	logset:hasPart :c1_0c0s6a0l04;
+	logset:hasPart :c1_0c0s6a0l05;
+	logset:hasPart :c1_0c0s6a0l06;
+	logset:hasPart :c1_0c0s6a0l07;
+	logset:hasPart :c1_0c0s6a0l10;
+	logset:hasPart :c1_0c0s6a0l11;
+	logset:hasPart :c1_0c0s6a0l12;
+	logset:hasPart :c1_0c0s6a0l13;
+	logset:hasPart :c1_0c0s6a0l14;
+	logset:hasPart :c1_0c0s6a0l15;
+	logset:hasPart :c1_0c0s6a0l16;
+	logset:hasPart :c1_0c0s6a0l17;
+	logset:hasPart :c1_0c0s6a0l20;
+	logset:hasPart :c1_0c0s6a0l21;
+	logset:hasPart :c1_0c0s6a0l22;
+	logset:hasPart :c1_0c0s6a0l23;
+	logset:hasPart :c1_0c0s6a0l24;
+	logset:hasPart :c1_0c0s6a0l25;
+	logset:hasPart :c1_0c0s6a0l26;
+	logset:hasPart :c1_0c0s6a0l27;
+	logset:hasPart :c1_0c0s6a0l30;
+	logset:hasPart :c1_0c0s6a0l31;
+	logset:hasPart :c1_0c0s6a0l32;
+	logset:hasPart :c1_0c0s6a0l33;
+	logset:hasPart :c1_0c0s6a0l34;
+	logset:hasPart :c1_0c0s6a0l35;
+	logset:hasPart :c1_0c0s6a0l36;
+	logset:hasPart :c1_0c0s6a0l37;
+	logset:hasPart :c1_0c0s6a0l40;
+	logset:hasPart :c1_0c0s6a0l41;
+	logset:hasPart :c1_0c0s6a0l42;
+	logset:hasPart :c1_0c0s6a0l43;
+	logset:hasPart :c1_0c0s6a0l44;
+	logset:hasPart :c1_0c0s6a0l45;
+	logset:hasPart :c1_0c0s6a0l46;
+	logset:hasPart :c1_0c0s6a0l47;
+	logset:hasPart :c1_0c0s6a0l50;
+	logset:hasPart :c1_0c0s6a0l51;
+	logset:hasPart :c1_0c0s6a0l52;
+	logset:hasPart :c1_0c0s6a0l53;
+	logset:hasPart :c1_0c0s6a0l54;
+	logset:hasPart :c1_0c0s6a0l55;
+	logset:hasPart :c1_0c0s6a0l56;
+	logset:hasPart :c1_0c0s6a0l57;
+	logset:hasPart :c1_0c0s6a0n0;
+	logset:hasPart :c1_0c0s6a0n1;
+	logset:hasPart :c1_0c0s6a0n2;
+	logset:hasPart :c1_0c0s6a0n3;
+	.
+
+:c1_0c0s7a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s7a0l00;
+	logset:hasPart :c1_0c0s7a0l01;
+	logset:hasPart :c1_0c0s7a0l02;
+	logset:hasPart :c1_0c0s7a0l03;
+	logset:hasPart :c1_0c0s7a0l04;
+	logset:hasPart :c1_0c0s7a0l05;
+	logset:hasPart :c1_0c0s7a0l06;
+	logset:hasPart :c1_0c0s7a0l07;
+	logset:hasPart :c1_0c0s7a0l10;
+	logset:hasPart :c1_0c0s7a0l11;
+	logset:hasPart :c1_0c0s7a0l12;
+	logset:hasPart :c1_0c0s7a0l13;
+	logset:hasPart :c1_0c0s7a0l14;
+	logset:hasPart :c1_0c0s7a0l15;
+	logset:hasPart :c1_0c0s7a0l16;
+	logset:hasPart :c1_0c0s7a0l17;
+	logset:hasPart :c1_0c0s7a0l20;
+	logset:hasPart :c1_0c0s7a0l21;
+	logset:hasPart :c1_0c0s7a0l22;
+	logset:hasPart :c1_0c0s7a0l23;
+	logset:hasPart :c1_0c0s7a0l24;
+	logset:hasPart :c1_0c0s7a0l25;
+	logset:hasPart :c1_0c0s7a0l26;
+	logset:hasPart :c1_0c0s7a0l27;
+	logset:hasPart :c1_0c0s7a0l30;
+	logset:hasPart :c1_0c0s7a0l31;
+	logset:hasPart :c1_0c0s7a0l32;
+	logset:hasPart :c1_0c0s7a0l33;
+	logset:hasPart :c1_0c0s7a0l34;
+	logset:hasPart :c1_0c0s7a0l35;
+	logset:hasPart :c1_0c0s7a0l36;
+	logset:hasPart :c1_0c0s7a0l37;
+	logset:hasPart :c1_0c0s7a0l40;
+	logset:hasPart :c1_0c0s7a0l41;
+	logset:hasPart :c1_0c0s7a0l42;
+	logset:hasPart :c1_0c0s7a0l43;
+	logset:hasPart :c1_0c0s7a0l44;
+	logset:hasPart :c1_0c0s7a0l45;
+	logset:hasPart :c1_0c0s7a0l46;
+	logset:hasPart :c1_0c0s7a0l47;
+	logset:hasPart :c1_0c0s7a0l50;
+	logset:hasPart :c1_0c0s7a0l51;
+	logset:hasPart :c1_0c0s7a0l52;
+	logset:hasPart :c1_0c0s7a0l53;
+	logset:hasPart :c1_0c0s7a0l54;
+	logset:hasPart :c1_0c0s7a0l55;
+	logset:hasPart :c1_0c0s7a0l56;
+	logset:hasPart :c1_0c0s7a0l57;
+	logset:hasPart :c1_0c0s7a0n0;
+	logset:hasPart :c1_0c0s7a0n1;
+	logset:hasPart :c1_0c0s7a0n2;
+	logset:hasPart :c1_0c0s7a0n3;
+	.
+
+:c1_0c0s8a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s8a0l00;
+	logset:hasPart :c1_0c0s8a0l01;
+	logset:hasPart :c1_0c0s8a0l02;
+	logset:hasPart :c1_0c0s8a0l03;
+	logset:hasPart :c1_0c0s8a0l04;
+	logset:hasPart :c1_0c0s8a0l05;
+	logset:hasPart :c1_0c0s8a0l06;
+	logset:hasPart :c1_0c0s8a0l07;
+	logset:hasPart :c1_0c0s8a0l10;
+	logset:hasPart :c1_0c0s8a0l11;
+	logset:hasPart :c1_0c0s8a0l12;
+	logset:hasPart :c1_0c0s8a0l13;
+	logset:hasPart :c1_0c0s8a0l14;
+	logset:hasPart :c1_0c0s8a0l15;
+	logset:hasPart :c1_0c0s8a0l16;
+	logset:hasPart :c1_0c0s8a0l17;
+	logset:hasPart :c1_0c0s8a0l20;
+	logset:hasPart :c1_0c0s8a0l21;
+	logset:hasPart :c1_0c0s8a0l22;
+	logset:hasPart :c1_0c0s8a0l23;
+	logset:hasPart :c1_0c0s8a0l24;
+	logset:hasPart :c1_0c0s8a0l25;
+	logset:hasPart :c1_0c0s8a0l26;
+	logset:hasPart :c1_0c0s8a0l27;
+	logset:hasPart :c1_0c0s8a0l30;
+	logset:hasPart :c1_0c0s8a0l31;
+	logset:hasPart :c1_0c0s8a0l32;
+	logset:hasPart :c1_0c0s8a0l33;
+	logset:hasPart :c1_0c0s8a0l34;
+	logset:hasPart :c1_0c0s8a0l35;
+	logset:hasPart :c1_0c0s8a0l36;
+	logset:hasPart :c1_0c0s8a0l37;
+	logset:hasPart :c1_0c0s8a0l40;
+	logset:hasPart :c1_0c0s8a0l41;
+	logset:hasPart :c1_0c0s8a0l42;
+	logset:hasPart :c1_0c0s8a0l43;
+	logset:hasPart :c1_0c0s8a0l44;
+	logset:hasPart :c1_0c0s8a0l45;
+	logset:hasPart :c1_0c0s8a0l46;
+	logset:hasPart :c1_0c0s8a0l47;
+	logset:hasPart :c1_0c0s8a0l50;
+	logset:hasPart :c1_0c0s8a0l51;
+	logset:hasPart :c1_0c0s8a0l52;
+	logset:hasPart :c1_0c0s8a0l53;
+	logset:hasPart :c1_0c0s8a0l54;
+	logset:hasPart :c1_0c0s8a0l55;
+	logset:hasPart :c1_0c0s8a0l56;
+	logset:hasPart :c1_0c0s8a0l57;
+	logset:hasPart :c1_0c0s8a0n0;
+	logset:hasPart :c1_0c0s8a0n1;
+	logset:hasPart :c1_0c0s8a0n2;
+	logset:hasPart :c1_0c0s8a0n3;
+	.
+
+:c1_0c0s9a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c0s9a0l00;
+	logset:hasPart :c1_0c0s9a0l01;
+	logset:hasPart :c1_0c0s9a0l02;
+	logset:hasPart :c1_0c0s9a0l03;
+	logset:hasPart :c1_0c0s9a0l04;
+	logset:hasPart :c1_0c0s9a0l05;
+	logset:hasPart :c1_0c0s9a0l06;
+	logset:hasPart :c1_0c0s9a0l07;
+	logset:hasPart :c1_0c0s9a0l10;
+	logset:hasPart :c1_0c0s9a0l11;
+	logset:hasPart :c1_0c0s9a0l12;
+	logset:hasPart :c1_0c0s9a0l13;
+	logset:hasPart :c1_0c0s9a0l14;
+	logset:hasPart :c1_0c0s9a0l15;
+	logset:hasPart :c1_0c0s9a0l16;
+	logset:hasPart :c1_0c0s9a0l17;
+	logset:hasPart :c1_0c0s9a0l20;
+	logset:hasPart :c1_0c0s9a0l21;
+	logset:hasPart :c1_0c0s9a0l22;
+	logset:hasPart :c1_0c0s9a0l23;
+	logset:hasPart :c1_0c0s9a0l24;
+	logset:hasPart :c1_0c0s9a0l25;
+	logset:hasPart :c1_0c0s9a0l26;
+	logset:hasPart :c1_0c0s9a0l27;
+	logset:hasPart :c1_0c0s9a0l30;
+	logset:hasPart :c1_0c0s9a0l31;
+	logset:hasPart :c1_0c0s9a0l32;
+	logset:hasPart :c1_0c0s9a0l33;
+	logset:hasPart :c1_0c0s9a0l34;
+	logset:hasPart :c1_0c0s9a0l35;
+	logset:hasPart :c1_0c0s9a0l36;
+	logset:hasPart :c1_0c0s9a0l37;
+	logset:hasPart :c1_0c0s9a0l40;
+	logset:hasPart :c1_0c0s9a0l41;
+	logset:hasPart :c1_0c0s9a0l42;
+	logset:hasPart :c1_0c0s9a0l43;
+	logset:hasPart :c1_0c0s9a0l44;
+	logset:hasPart :c1_0c0s9a0l45;
+	logset:hasPart :c1_0c0s9a0l46;
+	logset:hasPart :c1_0c0s9a0l47;
+	logset:hasPart :c1_0c0s9a0l50;
+	logset:hasPart :c1_0c0s9a0l51;
+	logset:hasPart :c1_0c0s9a0l52;
+	logset:hasPart :c1_0c0s9a0l53;
+	logset:hasPart :c1_0c0s9a0l54;
+	logset:hasPart :c1_0c0s9a0l55;
+	logset:hasPart :c1_0c0s9a0l56;
+	logset:hasPart :c1_0c0s9a0l57;
+	logset:hasPart :c1_0c0s9a0n0;
+	logset:hasPart :c1_0c0s9a0n1;
+	logset:hasPart :c1_0c0s9a0n2;
+	logset:hasPart :c1_0c0s9a0n3;
+	.
+
+:c1_0c1s0a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s0a0l00;
+	logset:hasPart :c1_0c1s0a0l01;
+	logset:hasPart :c1_0c1s0a0l02;
+	logset:hasPart :c1_0c1s0a0l03;
+	logset:hasPart :c1_0c1s0a0l04;
+	logset:hasPart :c1_0c1s0a0l05;
+	logset:hasPart :c1_0c1s0a0l06;
+	logset:hasPart :c1_0c1s0a0l07;
+	logset:hasPart :c1_0c1s0a0l10;
+	logset:hasPart :c1_0c1s0a0l11;
+	logset:hasPart :c1_0c1s0a0l12;
+	logset:hasPart :c1_0c1s0a0l13;
+	logset:hasPart :c1_0c1s0a0l14;
+	logset:hasPart :c1_0c1s0a0l15;
+	logset:hasPart :c1_0c1s0a0l16;
+	logset:hasPart :c1_0c1s0a0l17;
+	logset:hasPart :c1_0c1s0a0l20;
+	logset:hasPart :c1_0c1s0a0l21;
+	logset:hasPart :c1_0c1s0a0l22;
+	logset:hasPart :c1_0c1s0a0l23;
+	logset:hasPart :c1_0c1s0a0l24;
+	logset:hasPart :c1_0c1s0a0l25;
+	logset:hasPart :c1_0c1s0a0l26;
+	logset:hasPart :c1_0c1s0a0l27;
+	logset:hasPart :c1_0c1s0a0l30;
+	logset:hasPart :c1_0c1s0a0l31;
+	logset:hasPart :c1_0c1s0a0l32;
+	logset:hasPart :c1_0c1s0a0l33;
+	logset:hasPart :c1_0c1s0a0l34;
+	logset:hasPart :c1_0c1s0a0l35;
+	logset:hasPart :c1_0c1s0a0l36;
+	logset:hasPart :c1_0c1s0a0l37;
+	logset:hasPart :c1_0c1s0a0l40;
+	logset:hasPart :c1_0c1s0a0l41;
+	logset:hasPart :c1_0c1s0a0l42;
+	logset:hasPart :c1_0c1s0a0l43;
+	logset:hasPart :c1_0c1s0a0l44;
+	logset:hasPart :c1_0c1s0a0l45;
+	logset:hasPart :c1_0c1s0a0l46;
+	logset:hasPart :c1_0c1s0a0l47;
+	logset:hasPart :c1_0c1s0a0l50;
+	logset:hasPart :c1_0c1s0a0l51;
+	logset:hasPart :c1_0c1s0a0l52;
+	logset:hasPart :c1_0c1s0a0l53;
+	logset:hasPart :c1_0c1s0a0l54;
+	logset:hasPart :c1_0c1s0a0l55;
+	logset:hasPart :c1_0c1s0a0l56;
+	logset:hasPart :c1_0c1s0a0l57;
+	logset:hasPart :c1_0c1s0a0n0;
+	logset:hasPart :c1_0c1s0a0n1;
+	logset:hasPart :c1_0c1s0a0n2;
+	logset:hasPart :c1_0c1s0a0n3;
+	.
+
+:c1_0c1s10a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s10a0l00;
+	logset:hasPart :c1_0c1s10a0l01;
+	logset:hasPart :c1_0c1s10a0l02;
+	logset:hasPart :c1_0c1s10a0l03;
+	logset:hasPart :c1_0c1s10a0l04;
+	logset:hasPart :c1_0c1s10a0l05;
+	logset:hasPart :c1_0c1s10a0l06;
+	logset:hasPart :c1_0c1s10a0l07;
+	logset:hasPart :c1_0c1s10a0l10;
+	logset:hasPart :c1_0c1s10a0l11;
+	logset:hasPart :c1_0c1s10a0l12;
+	logset:hasPart :c1_0c1s10a0l13;
+	logset:hasPart :c1_0c1s10a0l14;
+	logset:hasPart :c1_0c1s10a0l15;
+	logset:hasPart :c1_0c1s10a0l16;
+	logset:hasPart :c1_0c1s10a0l17;
+	logset:hasPart :c1_0c1s10a0l20;
+	logset:hasPart :c1_0c1s10a0l21;
+	logset:hasPart :c1_0c1s10a0l22;
+	logset:hasPart :c1_0c1s10a0l23;
+	logset:hasPart :c1_0c1s10a0l24;
+	logset:hasPart :c1_0c1s10a0l25;
+	logset:hasPart :c1_0c1s10a0l26;
+	logset:hasPart :c1_0c1s10a0l27;
+	logset:hasPart :c1_0c1s10a0l30;
+	logset:hasPart :c1_0c1s10a0l31;
+	logset:hasPart :c1_0c1s10a0l32;
+	logset:hasPart :c1_0c1s10a0l33;
+	logset:hasPart :c1_0c1s10a0l34;
+	logset:hasPart :c1_0c1s10a0l35;
+	logset:hasPart :c1_0c1s10a0l36;
+	logset:hasPart :c1_0c1s10a0l37;
+	logset:hasPart :c1_0c1s10a0l40;
+	logset:hasPart :c1_0c1s10a0l41;
+	logset:hasPart :c1_0c1s10a0l42;
+	logset:hasPart :c1_0c1s10a0l43;
+	logset:hasPart :c1_0c1s10a0l44;
+	logset:hasPart :c1_0c1s10a0l45;
+	logset:hasPart :c1_0c1s10a0l46;
+	logset:hasPart :c1_0c1s10a0l47;
+	logset:hasPart :c1_0c1s10a0l50;
+	logset:hasPart :c1_0c1s10a0l51;
+	logset:hasPart :c1_0c1s10a0l52;
+	logset:hasPart :c1_0c1s10a0l53;
+	logset:hasPart :c1_0c1s10a0l54;
+	logset:hasPart :c1_0c1s10a0l55;
+	logset:hasPart :c1_0c1s10a0l56;
+	logset:hasPart :c1_0c1s10a0l57;
+	logset:hasPart :c1_0c1s10a0n0;
+	logset:hasPart :c1_0c1s10a0n1;
+	logset:hasPart :c1_0c1s10a0n2;
+	logset:hasPart :c1_0c1s10a0n3;
+	.
+
+:c1_0c1s11a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s11a0l00;
+	logset:hasPart :c1_0c1s11a0l01;
+	logset:hasPart :c1_0c1s11a0l02;
+	logset:hasPart :c1_0c1s11a0l03;
+	logset:hasPart :c1_0c1s11a0l04;
+	logset:hasPart :c1_0c1s11a0l05;
+	logset:hasPart :c1_0c1s11a0l06;
+	logset:hasPart :c1_0c1s11a0l07;
+	logset:hasPart :c1_0c1s11a0l10;
+	logset:hasPart :c1_0c1s11a0l11;
+	logset:hasPart :c1_0c1s11a0l12;
+	logset:hasPart :c1_0c1s11a0l13;
+	logset:hasPart :c1_0c1s11a0l14;
+	logset:hasPart :c1_0c1s11a0l15;
+	logset:hasPart :c1_0c1s11a0l16;
+	logset:hasPart :c1_0c1s11a0l17;
+	logset:hasPart :c1_0c1s11a0l20;
+	logset:hasPart :c1_0c1s11a0l21;
+	logset:hasPart :c1_0c1s11a0l22;
+	logset:hasPart :c1_0c1s11a0l23;
+	logset:hasPart :c1_0c1s11a0l24;
+	logset:hasPart :c1_0c1s11a0l25;
+	logset:hasPart :c1_0c1s11a0l26;
+	logset:hasPart :c1_0c1s11a0l27;
+	logset:hasPart :c1_0c1s11a0l30;
+	logset:hasPart :c1_0c1s11a0l31;
+	logset:hasPart :c1_0c1s11a0l32;
+	logset:hasPart :c1_0c1s11a0l33;
+	logset:hasPart :c1_0c1s11a0l34;
+	logset:hasPart :c1_0c1s11a0l35;
+	logset:hasPart :c1_0c1s11a0l36;
+	logset:hasPart :c1_0c1s11a0l37;
+	logset:hasPart :c1_0c1s11a0l40;
+	logset:hasPart :c1_0c1s11a0l41;
+	logset:hasPart :c1_0c1s11a0l42;
+	logset:hasPart :c1_0c1s11a0l43;
+	logset:hasPart :c1_0c1s11a0l44;
+	logset:hasPart :c1_0c1s11a0l45;
+	logset:hasPart :c1_0c1s11a0l46;
+	logset:hasPart :c1_0c1s11a0l47;
+	logset:hasPart :c1_0c1s11a0l50;
+	logset:hasPart :c1_0c1s11a0l51;
+	logset:hasPart :c1_0c1s11a0l52;
+	logset:hasPart :c1_0c1s11a0l53;
+	logset:hasPart :c1_0c1s11a0l54;
+	logset:hasPart :c1_0c1s11a0l55;
+	logset:hasPart :c1_0c1s11a0l56;
+	logset:hasPart :c1_0c1s11a0l57;
+	logset:hasPart :c1_0c1s11a0n0;
+	logset:hasPart :c1_0c1s11a0n1;
+	logset:hasPart :c1_0c1s11a0n2;
+	logset:hasPart :c1_0c1s11a0n3;
+	.
+
+:c1_0c1s12a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s12a0l00;
+	logset:hasPart :c1_0c1s12a0l01;
+	logset:hasPart :c1_0c1s12a0l02;
+	logset:hasPart :c1_0c1s12a0l03;
+	logset:hasPart :c1_0c1s12a0l04;
+	logset:hasPart :c1_0c1s12a0l05;
+	logset:hasPart :c1_0c1s12a0l06;
+	logset:hasPart :c1_0c1s12a0l07;
+	logset:hasPart :c1_0c1s12a0l10;
+	logset:hasPart :c1_0c1s12a0l11;
+	logset:hasPart :c1_0c1s12a0l12;
+	logset:hasPart :c1_0c1s12a0l13;
+	logset:hasPart :c1_0c1s12a0l14;
+	logset:hasPart :c1_0c1s12a0l15;
+	logset:hasPart :c1_0c1s12a0l16;
+	logset:hasPart :c1_0c1s12a0l17;
+	logset:hasPart :c1_0c1s12a0l20;
+	logset:hasPart :c1_0c1s12a0l21;
+	logset:hasPart :c1_0c1s12a0l22;
+	logset:hasPart :c1_0c1s12a0l23;
+	logset:hasPart :c1_0c1s12a0l24;
+	logset:hasPart :c1_0c1s12a0l25;
+	logset:hasPart :c1_0c1s12a0l26;
+	logset:hasPart :c1_0c1s12a0l27;
+	logset:hasPart :c1_0c1s12a0l30;
+	logset:hasPart :c1_0c1s12a0l31;
+	logset:hasPart :c1_0c1s12a0l32;
+	logset:hasPart :c1_0c1s12a0l33;
+	logset:hasPart :c1_0c1s12a0l34;
+	logset:hasPart :c1_0c1s12a0l35;
+	logset:hasPart :c1_0c1s12a0l36;
+	logset:hasPart :c1_0c1s12a0l37;
+	logset:hasPart :c1_0c1s12a0l40;
+	logset:hasPart :c1_0c1s12a0l41;
+	logset:hasPart :c1_0c1s12a0l42;
+	logset:hasPart :c1_0c1s12a0l43;
+	logset:hasPart :c1_0c1s12a0l44;
+	logset:hasPart :c1_0c1s12a0l45;
+	logset:hasPart :c1_0c1s12a0l46;
+	logset:hasPart :c1_0c1s12a0l47;
+	logset:hasPart :c1_0c1s12a0l50;
+	logset:hasPart :c1_0c1s12a0l51;
+	logset:hasPart :c1_0c1s12a0l52;
+	logset:hasPart :c1_0c1s12a0l53;
+	logset:hasPart :c1_0c1s12a0l54;
+	logset:hasPart :c1_0c1s12a0l55;
+	logset:hasPart :c1_0c1s12a0l56;
+	logset:hasPart :c1_0c1s12a0l57;
+	logset:hasPart :c1_0c1s12a0n0;
+	logset:hasPart :c1_0c1s12a0n1;
+	logset:hasPart :c1_0c1s12a0n2;
+	logset:hasPart :c1_0c1s12a0n3;
+	.
+
+:c1_0c1s13a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s13a0l00;
+	logset:hasPart :c1_0c1s13a0l01;
+	logset:hasPart :c1_0c1s13a0l02;
+	logset:hasPart :c1_0c1s13a0l03;
+	logset:hasPart :c1_0c1s13a0l04;
+	logset:hasPart :c1_0c1s13a0l05;
+	logset:hasPart :c1_0c1s13a0l06;
+	logset:hasPart :c1_0c1s13a0l07;
+	logset:hasPart :c1_0c1s13a0l10;
+	logset:hasPart :c1_0c1s13a0l11;
+	logset:hasPart :c1_0c1s13a0l12;
+	logset:hasPart :c1_0c1s13a0l13;
+	logset:hasPart :c1_0c1s13a0l14;
+	logset:hasPart :c1_0c1s13a0l15;
+	logset:hasPart :c1_0c1s13a0l16;
+	logset:hasPart :c1_0c1s13a0l17;
+	logset:hasPart :c1_0c1s13a0l20;
+	logset:hasPart :c1_0c1s13a0l21;
+	logset:hasPart :c1_0c1s13a0l22;
+	logset:hasPart :c1_0c1s13a0l23;
+	logset:hasPart :c1_0c1s13a0l24;
+	logset:hasPart :c1_0c1s13a0l25;
+	logset:hasPart :c1_0c1s13a0l26;
+	logset:hasPart :c1_0c1s13a0l27;
+	logset:hasPart :c1_0c1s13a0l30;
+	logset:hasPart :c1_0c1s13a0l31;
+	logset:hasPart :c1_0c1s13a0l32;
+	logset:hasPart :c1_0c1s13a0l33;
+	logset:hasPart :c1_0c1s13a0l34;
+	logset:hasPart :c1_0c1s13a0l35;
+	logset:hasPart :c1_0c1s13a0l36;
+	logset:hasPart :c1_0c1s13a0l37;
+	logset:hasPart :c1_0c1s13a0l40;
+	logset:hasPart :c1_0c1s13a0l41;
+	logset:hasPart :c1_0c1s13a0l42;
+	logset:hasPart :c1_0c1s13a0l43;
+	logset:hasPart :c1_0c1s13a0l44;
+	logset:hasPart :c1_0c1s13a0l45;
+	logset:hasPart :c1_0c1s13a0l46;
+	logset:hasPart :c1_0c1s13a0l47;
+	logset:hasPart :c1_0c1s13a0l50;
+	logset:hasPart :c1_0c1s13a0l51;
+	logset:hasPart :c1_0c1s13a0l52;
+	logset:hasPart :c1_0c1s13a0l53;
+	logset:hasPart :c1_0c1s13a0l54;
+	logset:hasPart :c1_0c1s13a0l55;
+	logset:hasPart :c1_0c1s13a0l56;
+	logset:hasPart :c1_0c1s13a0l57;
+	logset:hasPart :c1_0c1s13a0n0;
+	logset:hasPart :c1_0c1s13a0n1;
+	logset:hasPart :c1_0c1s13a0n2;
+	logset:hasPart :c1_0c1s13a0n3;
+	.
+
+:c1_0c1s1a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s1a0l00;
+	logset:hasPart :c1_0c1s1a0l01;
+	logset:hasPart :c1_0c1s1a0l02;
+	logset:hasPart :c1_0c1s1a0l03;
+	logset:hasPart :c1_0c1s1a0l04;
+	logset:hasPart :c1_0c1s1a0l05;
+	logset:hasPart :c1_0c1s1a0l06;
+	logset:hasPart :c1_0c1s1a0l07;
+	logset:hasPart :c1_0c1s1a0l10;
+	logset:hasPart :c1_0c1s1a0l11;
+	logset:hasPart :c1_0c1s1a0l12;
+	logset:hasPart :c1_0c1s1a0l13;
+	logset:hasPart :c1_0c1s1a0l14;
+	logset:hasPart :c1_0c1s1a0l15;
+	logset:hasPart :c1_0c1s1a0l16;
+	logset:hasPart :c1_0c1s1a0l17;
+	logset:hasPart :c1_0c1s1a0l20;
+	logset:hasPart :c1_0c1s1a0l21;
+	logset:hasPart :c1_0c1s1a0l22;
+	logset:hasPart :c1_0c1s1a0l23;
+	logset:hasPart :c1_0c1s1a0l24;
+	logset:hasPart :c1_0c1s1a0l25;
+	logset:hasPart :c1_0c1s1a0l26;
+	logset:hasPart :c1_0c1s1a0l27;
+	logset:hasPart :c1_0c1s1a0l30;
+	logset:hasPart :c1_0c1s1a0l31;
+	logset:hasPart :c1_0c1s1a0l32;
+	logset:hasPart :c1_0c1s1a0l33;
+	logset:hasPart :c1_0c1s1a0l34;
+	logset:hasPart :c1_0c1s1a0l35;
+	logset:hasPart :c1_0c1s1a0l36;
+	logset:hasPart :c1_0c1s1a0l37;
+	logset:hasPart :c1_0c1s1a0l40;
+	logset:hasPart :c1_0c1s1a0l41;
+	logset:hasPart :c1_0c1s1a0l42;
+	logset:hasPart :c1_0c1s1a0l43;
+	logset:hasPart :c1_0c1s1a0l44;
+	logset:hasPart :c1_0c1s1a0l45;
+	logset:hasPart :c1_0c1s1a0l46;
+	logset:hasPart :c1_0c1s1a0l47;
+	logset:hasPart :c1_0c1s1a0l50;
+	logset:hasPart :c1_0c1s1a0l51;
+	logset:hasPart :c1_0c1s1a0l52;
+	logset:hasPart :c1_0c1s1a0l53;
+	logset:hasPart :c1_0c1s1a0l54;
+	logset:hasPart :c1_0c1s1a0l55;
+	logset:hasPart :c1_0c1s1a0l56;
+	logset:hasPart :c1_0c1s1a0l57;
+	logset:hasPart :c1_0c1s1a0n0;
+	logset:hasPart :c1_0c1s1a0n1;
+	logset:hasPart :c1_0c1s1a0n2;
+	logset:hasPart :c1_0c1s1a0n3;
+	.
+
+:c1_0c1s2a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s2a0l00;
+	logset:hasPart :c1_0c1s2a0l01;
+	logset:hasPart :c1_0c1s2a0l02;
+	logset:hasPart :c1_0c1s2a0l03;
+	logset:hasPart :c1_0c1s2a0l04;
+	logset:hasPart :c1_0c1s2a0l05;
+	logset:hasPart :c1_0c1s2a0l06;
+	logset:hasPart :c1_0c1s2a0l07;
+	logset:hasPart :c1_0c1s2a0l10;
+	logset:hasPart :c1_0c1s2a0l11;
+	logset:hasPart :c1_0c1s2a0l12;
+	logset:hasPart :c1_0c1s2a0l13;
+	logset:hasPart :c1_0c1s2a0l14;
+	logset:hasPart :c1_0c1s2a0l15;
+	logset:hasPart :c1_0c1s2a0l16;
+	logset:hasPart :c1_0c1s2a0l17;
+	logset:hasPart :c1_0c1s2a0l20;
+	logset:hasPart :c1_0c1s2a0l21;
+	logset:hasPart :c1_0c1s2a0l22;
+	logset:hasPart :c1_0c1s2a0l23;
+	logset:hasPart :c1_0c1s2a0l24;
+	logset:hasPart :c1_0c1s2a0l25;
+	logset:hasPart :c1_0c1s2a0l26;
+	logset:hasPart :c1_0c1s2a0l27;
+	logset:hasPart :c1_0c1s2a0l30;
+	logset:hasPart :c1_0c1s2a0l31;
+	logset:hasPart :c1_0c1s2a0l32;
+	logset:hasPart :c1_0c1s2a0l33;
+	logset:hasPart :c1_0c1s2a0l34;
+	logset:hasPart :c1_0c1s2a0l35;
+	logset:hasPart :c1_0c1s2a0l36;
+	logset:hasPart :c1_0c1s2a0l37;
+	logset:hasPart :c1_0c1s2a0l40;
+	logset:hasPart :c1_0c1s2a0l41;
+	logset:hasPart :c1_0c1s2a0l42;
+	logset:hasPart :c1_0c1s2a0l43;
+	logset:hasPart :c1_0c1s2a0l44;
+	logset:hasPart :c1_0c1s2a0l45;
+	logset:hasPart :c1_0c1s2a0l46;
+	logset:hasPart :c1_0c1s2a0l47;
+	logset:hasPart :c1_0c1s2a0l50;
+	logset:hasPart :c1_0c1s2a0l51;
+	logset:hasPart :c1_0c1s2a0l52;
+	logset:hasPart :c1_0c1s2a0l53;
+	logset:hasPart :c1_0c1s2a0l54;
+	logset:hasPart :c1_0c1s2a0l55;
+	logset:hasPart :c1_0c1s2a0l56;
+	logset:hasPart :c1_0c1s2a0l57;
+	logset:hasPart :c1_0c1s2a0n0;
+	logset:hasPart :c1_0c1s2a0n1;
+	logset:hasPart :c1_0c1s2a0n2;
+	logset:hasPart :c1_0c1s2a0n3;
+	.
+
+:c1_0c1s3a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s3a0l00;
+	logset:hasPart :c1_0c1s3a0l01;
+	logset:hasPart :c1_0c1s3a0l02;
+	logset:hasPart :c1_0c1s3a0l03;
+	logset:hasPart :c1_0c1s3a0l04;
+	logset:hasPart :c1_0c1s3a0l05;
+	logset:hasPart :c1_0c1s3a0l06;
+	logset:hasPart :c1_0c1s3a0l07;
+	logset:hasPart :c1_0c1s3a0l10;
+	logset:hasPart :c1_0c1s3a0l11;
+	logset:hasPart :c1_0c1s3a0l12;
+	logset:hasPart :c1_0c1s3a0l13;
+	logset:hasPart :c1_0c1s3a0l14;
+	logset:hasPart :c1_0c1s3a0l15;
+	logset:hasPart :c1_0c1s3a0l16;
+	logset:hasPart :c1_0c1s3a0l17;
+	logset:hasPart :c1_0c1s3a0l20;
+	logset:hasPart :c1_0c1s3a0l21;
+	logset:hasPart :c1_0c1s3a0l22;
+	logset:hasPart :c1_0c1s3a0l23;
+	logset:hasPart :c1_0c1s3a0l24;
+	logset:hasPart :c1_0c1s3a0l25;
+	logset:hasPart :c1_0c1s3a0l26;
+	logset:hasPart :c1_0c1s3a0l27;
+	logset:hasPart :c1_0c1s3a0l30;
+	logset:hasPart :c1_0c1s3a0l31;
+	logset:hasPart :c1_0c1s3a0l32;
+	logset:hasPart :c1_0c1s3a0l33;
+	logset:hasPart :c1_0c1s3a0l34;
+	logset:hasPart :c1_0c1s3a0l35;
+	logset:hasPart :c1_0c1s3a0l36;
+	logset:hasPart :c1_0c1s3a0l37;
+	logset:hasPart :c1_0c1s3a0l40;
+	logset:hasPart :c1_0c1s3a0l41;
+	logset:hasPart :c1_0c1s3a0l42;
+	logset:hasPart :c1_0c1s3a0l43;
+	logset:hasPart :c1_0c1s3a0l44;
+	logset:hasPart :c1_0c1s3a0l45;
+	logset:hasPart :c1_0c1s3a0l46;
+	logset:hasPart :c1_0c1s3a0l47;
+	logset:hasPart :c1_0c1s3a0l50;
+	logset:hasPart :c1_0c1s3a0l51;
+	logset:hasPart :c1_0c1s3a0l52;
+	logset:hasPart :c1_0c1s3a0l53;
+	logset:hasPart :c1_0c1s3a0l54;
+	logset:hasPart :c1_0c1s3a0l55;
+	logset:hasPart :c1_0c1s3a0l56;
+	logset:hasPart :c1_0c1s3a0l57;
+	logset:hasPart :c1_0c1s3a0n0;
+	logset:hasPart :c1_0c1s3a0n1;
+	logset:hasPart :c1_0c1s3a0n2;
+	logset:hasPart :c1_0c1s3a0n3;
+	.
+
+:c1_0c1s4a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s4a0l00;
+	logset:hasPart :c1_0c1s4a0l01;
+	logset:hasPart :c1_0c1s4a0l02;
+	logset:hasPart :c1_0c1s4a0l03;
+	logset:hasPart :c1_0c1s4a0l04;
+	logset:hasPart :c1_0c1s4a0l05;
+	logset:hasPart :c1_0c1s4a0l06;
+	logset:hasPart :c1_0c1s4a0l07;
+	logset:hasPart :c1_0c1s4a0l10;
+	logset:hasPart :c1_0c1s4a0l11;
+	logset:hasPart :c1_0c1s4a0l12;
+	logset:hasPart :c1_0c1s4a0l13;
+	logset:hasPart :c1_0c1s4a0l14;
+	logset:hasPart :c1_0c1s4a0l15;
+	logset:hasPart :c1_0c1s4a0l16;
+	logset:hasPart :c1_0c1s4a0l17;
+	logset:hasPart :c1_0c1s4a0l20;
+	logset:hasPart :c1_0c1s4a0l21;
+	logset:hasPart :c1_0c1s4a0l22;
+	logset:hasPart :c1_0c1s4a0l23;
+	logset:hasPart :c1_0c1s4a0l24;
+	logset:hasPart :c1_0c1s4a0l25;
+	logset:hasPart :c1_0c1s4a0l26;
+	logset:hasPart :c1_0c1s4a0l27;
+	logset:hasPart :c1_0c1s4a0l30;
+	logset:hasPart :c1_0c1s4a0l31;
+	logset:hasPart :c1_0c1s4a0l32;
+	logset:hasPart :c1_0c1s4a0l33;
+	logset:hasPart :c1_0c1s4a0l34;
+	logset:hasPart :c1_0c1s4a0l35;
+	logset:hasPart :c1_0c1s4a0l36;
+	logset:hasPart :c1_0c1s4a0l37;
+	logset:hasPart :c1_0c1s4a0l40;
+	logset:hasPart :c1_0c1s4a0l41;
+	logset:hasPart :c1_0c1s4a0l42;
+	logset:hasPart :c1_0c1s4a0l43;
+	logset:hasPart :c1_0c1s4a0l44;
+	logset:hasPart :c1_0c1s4a0l45;
+	logset:hasPart :c1_0c1s4a0l46;
+	logset:hasPart :c1_0c1s4a0l47;
+	logset:hasPart :c1_0c1s4a0l50;
+	logset:hasPart :c1_0c1s4a0l51;
+	logset:hasPart :c1_0c1s4a0l52;
+	logset:hasPart :c1_0c1s4a0l53;
+	logset:hasPart :c1_0c1s4a0l54;
+	logset:hasPart :c1_0c1s4a0l55;
+	logset:hasPart :c1_0c1s4a0l56;
+	logset:hasPart :c1_0c1s4a0l57;
+	logset:hasPart :c1_0c1s4a0n0;
+	logset:hasPart :c1_0c1s4a0n1;
+	logset:hasPart :c1_0c1s4a0n2;
+	logset:hasPart :c1_0c1s4a0n3;
+	.
+
+:c1_0c1s5a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s5a0l00;
+	logset:hasPart :c1_0c1s5a0l01;
+	logset:hasPart :c1_0c1s5a0l02;
+	logset:hasPart :c1_0c1s5a0l03;
+	logset:hasPart :c1_0c1s5a0l04;
+	logset:hasPart :c1_0c1s5a0l05;
+	logset:hasPart :c1_0c1s5a0l06;
+	logset:hasPart :c1_0c1s5a0l07;
+	logset:hasPart :c1_0c1s5a0l10;
+	logset:hasPart :c1_0c1s5a0l11;
+	logset:hasPart :c1_0c1s5a0l12;
+	logset:hasPart :c1_0c1s5a0l13;
+	logset:hasPart :c1_0c1s5a0l14;
+	logset:hasPart :c1_0c1s5a0l15;
+	logset:hasPart :c1_0c1s5a0l16;
+	logset:hasPart :c1_0c1s5a0l17;
+	logset:hasPart :c1_0c1s5a0l20;
+	logset:hasPart :c1_0c1s5a0l21;
+	logset:hasPart :c1_0c1s5a0l22;
+	logset:hasPart :c1_0c1s5a0l23;
+	logset:hasPart :c1_0c1s5a0l24;
+	logset:hasPart :c1_0c1s5a0l25;
+	logset:hasPart :c1_0c1s5a0l26;
+	logset:hasPart :c1_0c1s5a0l27;
+	logset:hasPart :c1_0c1s5a0l30;
+	logset:hasPart :c1_0c1s5a0l31;
+	logset:hasPart :c1_0c1s5a0l32;
+	logset:hasPart :c1_0c1s5a0l33;
+	logset:hasPart :c1_0c1s5a0l34;
+	logset:hasPart :c1_0c1s5a0l35;
+	logset:hasPart :c1_0c1s5a0l36;
+	logset:hasPart :c1_0c1s5a0l37;
+	logset:hasPart :c1_0c1s5a0l40;
+	logset:hasPart :c1_0c1s5a0l41;
+	logset:hasPart :c1_0c1s5a0l42;
+	logset:hasPart :c1_0c1s5a0l43;
+	logset:hasPart :c1_0c1s5a0l44;
+	logset:hasPart :c1_0c1s5a0l45;
+	logset:hasPart :c1_0c1s5a0l46;
+	logset:hasPart :c1_0c1s5a0l47;
+	logset:hasPart :c1_0c1s5a0l50;
+	logset:hasPart :c1_0c1s5a0l51;
+	logset:hasPart :c1_0c1s5a0l52;
+	logset:hasPart :c1_0c1s5a0l53;
+	logset:hasPart :c1_0c1s5a0l54;
+	logset:hasPart :c1_0c1s5a0l55;
+	logset:hasPart :c1_0c1s5a0l56;
+	logset:hasPart :c1_0c1s5a0l57;
+	logset:hasPart :c1_0c1s5a0n0;
+	logset:hasPart :c1_0c1s5a0n1;
+	logset:hasPart :c1_0c1s5a0n2;
+	logset:hasPart :c1_0c1s5a0n3;
+	.
+
+:c1_0c1s6a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s6a0l00;
+	logset:hasPart :c1_0c1s6a0l01;
+	logset:hasPart :c1_0c1s6a0l02;
+	logset:hasPart :c1_0c1s6a0l03;
+	logset:hasPart :c1_0c1s6a0l04;
+	logset:hasPart :c1_0c1s6a0l05;
+	logset:hasPart :c1_0c1s6a0l06;
+	logset:hasPart :c1_0c1s6a0l07;
+	logset:hasPart :c1_0c1s6a0l10;
+	logset:hasPart :c1_0c1s6a0l11;
+	logset:hasPart :c1_0c1s6a0l12;
+	logset:hasPart :c1_0c1s6a0l13;
+	logset:hasPart :c1_0c1s6a0l14;
+	logset:hasPart :c1_0c1s6a0l15;
+	logset:hasPart :c1_0c1s6a0l16;
+	logset:hasPart :c1_0c1s6a0l17;
+	logset:hasPart :c1_0c1s6a0l20;
+	logset:hasPart :c1_0c1s6a0l21;
+	logset:hasPart :c1_0c1s6a0l22;
+	logset:hasPart :c1_0c1s6a0l23;
+	logset:hasPart :c1_0c1s6a0l24;
+	logset:hasPart :c1_0c1s6a0l25;
+	logset:hasPart :c1_0c1s6a0l26;
+	logset:hasPart :c1_0c1s6a0l27;
+	logset:hasPart :c1_0c1s6a0l30;
+	logset:hasPart :c1_0c1s6a0l31;
+	logset:hasPart :c1_0c1s6a0l32;
+	logset:hasPart :c1_0c1s6a0l33;
+	logset:hasPart :c1_0c1s6a0l34;
+	logset:hasPart :c1_0c1s6a0l35;
+	logset:hasPart :c1_0c1s6a0l36;
+	logset:hasPart :c1_0c1s6a0l37;
+	logset:hasPart :c1_0c1s6a0l40;
+	logset:hasPart :c1_0c1s6a0l41;
+	logset:hasPart :c1_0c1s6a0l42;
+	logset:hasPart :c1_0c1s6a0l43;
+	logset:hasPart :c1_0c1s6a0l44;
+	logset:hasPart :c1_0c1s6a0l45;
+	logset:hasPart :c1_0c1s6a0l46;
+	logset:hasPart :c1_0c1s6a0l47;
+	logset:hasPart :c1_0c1s6a0l50;
+	logset:hasPart :c1_0c1s6a0l51;
+	logset:hasPart :c1_0c1s6a0l52;
+	logset:hasPart :c1_0c1s6a0l53;
+	logset:hasPart :c1_0c1s6a0l54;
+	logset:hasPart :c1_0c1s6a0l55;
+	logset:hasPart :c1_0c1s6a0l56;
+	logset:hasPart :c1_0c1s6a0l57;
+	logset:hasPart :c1_0c1s6a0n0;
+	logset:hasPart :c1_0c1s6a0n1;
+	logset:hasPart :c1_0c1s6a0n2;
+	logset:hasPart :c1_0c1s6a0n3;
+	.
+
+:c1_0c1s7a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s7a0l00;
+	logset:hasPart :c1_0c1s7a0l01;
+	logset:hasPart :c1_0c1s7a0l02;
+	logset:hasPart :c1_0c1s7a0l03;
+	logset:hasPart :c1_0c1s7a0l04;
+	logset:hasPart :c1_0c1s7a0l05;
+	logset:hasPart :c1_0c1s7a0l06;
+	logset:hasPart :c1_0c1s7a0l07;
+	logset:hasPart :c1_0c1s7a0l10;
+	logset:hasPart :c1_0c1s7a0l11;
+	logset:hasPart :c1_0c1s7a0l12;
+	logset:hasPart :c1_0c1s7a0l13;
+	logset:hasPart :c1_0c1s7a0l14;
+	logset:hasPart :c1_0c1s7a0l15;
+	logset:hasPart :c1_0c1s7a0l16;
+	logset:hasPart :c1_0c1s7a0l17;
+	logset:hasPart :c1_0c1s7a0l20;
+	logset:hasPart :c1_0c1s7a0l21;
+	logset:hasPart :c1_0c1s7a0l22;
+	logset:hasPart :c1_0c1s7a0l23;
+	logset:hasPart :c1_0c1s7a0l24;
+	logset:hasPart :c1_0c1s7a0l25;
+	logset:hasPart :c1_0c1s7a0l26;
+	logset:hasPart :c1_0c1s7a0l27;
+	logset:hasPart :c1_0c1s7a0l30;
+	logset:hasPart :c1_0c1s7a0l31;
+	logset:hasPart :c1_0c1s7a0l32;
+	logset:hasPart :c1_0c1s7a0l33;
+	logset:hasPart :c1_0c1s7a0l34;
+	logset:hasPart :c1_0c1s7a0l35;
+	logset:hasPart :c1_0c1s7a0l36;
+	logset:hasPart :c1_0c1s7a0l37;
+	logset:hasPart :c1_0c1s7a0l40;
+	logset:hasPart :c1_0c1s7a0l41;
+	logset:hasPart :c1_0c1s7a0l42;
+	logset:hasPart :c1_0c1s7a0l43;
+	logset:hasPart :c1_0c1s7a0l44;
+	logset:hasPart :c1_0c1s7a0l45;
+	logset:hasPart :c1_0c1s7a0l46;
+	logset:hasPart :c1_0c1s7a0l47;
+	logset:hasPart :c1_0c1s7a0l50;
+	logset:hasPart :c1_0c1s7a0l51;
+	logset:hasPart :c1_0c1s7a0l52;
+	logset:hasPart :c1_0c1s7a0l53;
+	logset:hasPart :c1_0c1s7a0l54;
+	logset:hasPart :c1_0c1s7a0l55;
+	logset:hasPart :c1_0c1s7a0l56;
+	logset:hasPart :c1_0c1s7a0l57;
+	logset:hasPart :c1_0c1s7a0n0;
+	logset:hasPart :c1_0c1s7a0n1;
+	logset:hasPart :c1_0c1s7a0n2;
+	logset:hasPart :c1_0c1s7a0n3;
+	.
+
+:c1_0c1s8a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s8a0l00;
+	logset:hasPart :c1_0c1s8a0l01;
+	logset:hasPart :c1_0c1s8a0l02;
+	logset:hasPart :c1_0c1s8a0l03;
+	logset:hasPart :c1_0c1s8a0l04;
+	logset:hasPart :c1_0c1s8a0l05;
+	logset:hasPart :c1_0c1s8a0l06;
+	logset:hasPart :c1_0c1s8a0l07;
+	logset:hasPart :c1_0c1s8a0l10;
+	logset:hasPart :c1_0c1s8a0l11;
+	logset:hasPart :c1_0c1s8a0l12;
+	logset:hasPart :c1_0c1s8a0l13;
+	logset:hasPart :c1_0c1s8a0l14;
+	logset:hasPart :c1_0c1s8a0l15;
+	logset:hasPart :c1_0c1s8a0l16;
+	logset:hasPart :c1_0c1s8a0l17;
+	logset:hasPart :c1_0c1s8a0l20;
+	logset:hasPart :c1_0c1s8a0l21;
+	logset:hasPart :c1_0c1s8a0l22;
+	logset:hasPart :c1_0c1s8a0l23;
+	logset:hasPart :c1_0c1s8a0l24;
+	logset:hasPart :c1_0c1s8a0l25;
+	logset:hasPart :c1_0c1s8a0l26;
+	logset:hasPart :c1_0c1s8a0l27;
+	logset:hasPart :c1_0c1s8a0l30;
+	logset:hasPart :c1_0c1s8a0l31;
+	logset:hasPart :c1_0c1s8a0l32;
+	logset:hasPart :c1_0c1s8a0l33;
+	logset:hasPart :c1_0c1s8a0l34;
+	logset:hasPart :c1_0c1s8a0l35;
+	logset:hasPart :c1_0c1s8a0l36;
+	logset:hasPart :c1_0c1s8a0l37;
+	logset:hasPart :c1_0c1s8a0l40;
+	logset:hasPart :c1_0c1s8a0l41;
+	logset:hasPart :c1_0c1s8a0l42;
+	logset:hasPart :c1_0c1s8a0l43;
+	logset:hasPart :c1_0c1s8a0l44;
+	logset:hasPart :c1_0c1s8a0l45;
+	logset:hasPart :c1_0c1s8a0l46;
+	logset:hasPart :c1_0c1s8a0l47;
+	logset:hasPart :c1_0c1s8a0l50;
+	logset:hasPart :c1_0c1s8a0l51;
+	logset:hasPart :c1_0c1s8a0l52;
+	logset:hasPart :c1_0c1s8a0l53;
+	logset:hasPart :c1_0c1s8a0l54;
+	logset:hasPart :c1_0c1s8a0l55;
+	logset:hasPart :c1_0c1s8a0l56;
+	logset:hasPart :c1_0c1s8a0l57;
+	logset:hasPart :c1_0c1s8a0n0;
+	logset:hasPart :c1_0c1s8a0n1;
+	logset:hasPart :c1_0c1s8a0n2;
+	logset:hasPart :c1_0c1s8a0n3;
+	.
+
+:c1_0c1s9a0 a craydict:AriesRouter ;
+	logset:hasPart :c1_0c1s9a0l00;
+	logset:hasPart :c1_0c1s9a0l01;
+	logset:hasPart :c1_0c1s9a0l02;
+	logset:hasPart :c1_0c1s9a0l03;
+	logset:hasPart :c1_0c1s9a0l04;
+	logset:hasPart :c1_0c1s9a0l05;
+	logset:hasPart :c1_0c1s9a0l06;
+	logset:hasPart :c1_0c1s9a0l07;
+	logset:hasPart :c1_0c1s9a0l10;
+	logset:hasPart :c1_0c1s9a0l11;
+	logset:hasPart :c1_0c1s9a0l12;
+	logset:hasPart :c1_0c1s9a0l13;
+	logset:hasPart :c1_0c1s9a0l14;
+	logset:hasPart :c1_0c1s9a0l15;
+	logset:hasPart :c1_0c1s9a0l16;
+	logset:hasPart :c1_0c1s9a0l17;
+	logset:hasPart :c1_0c1s9a0l20;
+	logset:hasPart :c1_0c1s9a0l21;
+	logset:hasPart :c1_0c1s9a0l22;
+	logset:hasPart :c1_0c1s9a0l23;
+	logset:hasPart :c1_0c1s9a0l24;
+	logset:hasPart :c1_0c1s9a0l25;
+	logset:hasPart :c1_0c1s9a0l26;
+	logset:hasPart :c1_0c1s9a0l27;
+	logset:hasPart :c1_0c1s9a0l30;
+	logset:hasPart :c1_0c1s9a0l31;
+	logset:hasPart :c1_0c1s9a0l32;
+	logset:hasPart :c1_0c1s9a0l33;
+	logset:hasPart :c1_0c1s9a0l34;
+	logset:hasPart :c1_0c1s9a0l35;
+	logset:hasPart :c1_0c1s9a0l36;
+	logset:hasPart :c1_0c1s9a0l37;
+	logset:hasPart :c1_0c1s9a0l40;
+	logset:hasPart :c1_0c1s9a0l41;
+	logset:hasPart :c1_0c1s9a0l42;
+	logset:hasPart :c1_0c1s9a0l43;
+	logset:hasPart :c1_0c1s9a0l44;
+	logset:hasPart :c1_0c1s9a0l45;
+	logset:hasPart :c1_0c1s9a0l46;
+	logset:hasPart :c1_0c1s9a0l47;
+	logset:hasPart :c1_0c1s9a0l50;
+	logset:hasPart :c1_0c1s9a0l51;
+	logset:hasPart :c1_0c1s9a0l52;
+	logset:hasPart :c1_0c1s9a0l53;
+	logset:hasPart :c1_0c1s9a0l54;
+	logset:hasPart :c1_0c1s9a0l55;
+	logset:hasPart :c1_0c1s9a0l56;
+	logset:hasPart :c1_0c1s9a0l57;
+	logset:hasPart :c1_0c1s9a0n0;
+	logset:hasPart :c1_0c1s9a0n1;
+	logset:hasPart :c1_0c1s9a0n2;
+	logset:hasPart :c1_0c1s9a0n3;
+	.
+
+:linkc0_0c0s0a0l00 a craydict:GreenLink .
+:linkc0_0c0s0a0l10 a craydict:GreenLink .
+:linkc0_0c0s0a0l11 a craydict:GreenLink .
+:linkc0_0c0s0a0l20 a craydict:GreenLink .
+:linkc0_0c0s0a0l21 a craydict:GreenLink .
+:linkc0_0c0s0a0l22 a craydict:GreenLink .
+:linkc0_0c0s0a0l23 a craydict:GreenLink .
+:linkc0_0c0s0a0l24 a craydict:BlackLink .
+:linkc0_0c0s0a0l25 a craydict:BlackLink .
+:linkc0_0c0s0a0l26 a craydict:BlackLink .
+:linkc0_0c0s0a0l27 a craydict:BlackLink .
+:linkc0_0c0s0a0l31 a craydict:GreenLink .
+:linkc0_0c0s0a0l32 a craydict:GreenLink .
+:linkc0_0c0s0a0l33 a craydict:GreenLink .
+:linkc0_0c0s0a0l34 a craydict:BlackLink .
+:linkc0_0c0s0a0l35 a craydict:BlackLink .
+:linkc0_0c0s0a0l36 a craydict:BlackLink .
+:linkc0_0c0s0a0l37 a craydict:BlackLink .
+:linkc0_0c0s0a0l43 a craydict:GreenLink .
+:linkc0_0c0s0a0l44 a craydict:BlackLink .
+:linkc0_0c0s0a0l45 a craydict:BlackLink .
+:linkc0_0c0s0a0l46 a craydict:BlackLink .
+:linkc0_0c0s0a0l47 a craydict:BlackLink .
+:linkc0_0c0s0a0l50 a craydict:PtileLink .
+:linkc0_0c0s0a0l51 a craydict:PtileLink .
+:linkc0_0c0s0a0l52 a craydict:PtileLink .
+:linkc0_0c0s0a0l53 a craydict:PtileLink .
+:linkc0_0c0s0a0l54 a craydict:PtileLink .
+:linkc0_0c0s0a0l55 a craydict:PtileLink .
+:linkc0_0c0s0a0l56 a craydict:PtileLink .
+:linkc0_0c0s0a0l57 a craydict:PtileLink .
+:linkc0_0c0s10a0l20 a craydict:BlackLink .
+:linkc0_0c0s10a0l21 a craydict:BlackLink .
+:linkc0_0c0s10a0l22 a craydict:BlackLink .
+:linkc0_0c0s10a0l23 a craydict:BlackLink .
+:linkc0_0c0s10a0l24 a craydict:GreenLink .
+:linkc0_0c0s10a0l30 a craydict:BlackLink .
+:linkc0_0c0s10a0l31 a craydict:BlackLink .
+:linkc0_0c0s10a0l32 a craydict:BlackLink .
+:linkc0_0c0s10a0l33 a craydict:BlackLink .
+:linkc0_0c0s10a0l40 a craydict:BlackLink .
+:linkc0_0c0s10a0l41 a craydict:BlackLink .
+:linkc0_0c0s10a0l42 a craydict:BlackLink .
+:linkc0_0c0s10a0l43 a craydict:BlackLink .
+:linkc0_0c0s10a0l50 a craydict:PtileLink .
+:linkc0_0c0s10a0l51 a craydict:PtileLink .
+:linkc0_0c0s10a0l52 a craydict:PtileLink .
+:linkc0_0c0s10a0l53 a craydict:PtileLink .
+:linkc0_0c0s10a0l54 a craydict:PtileLink .
+:linkc0_0c0s10a0l55 a craydict:PtileLink .
+:linkc0_0c0s10a0l56 a craydict:PtileLink .
+:linkc0_0c0s10a0l57 a craydict:PtileLink .
+:linkc0_0c0s11a0l20 a craydict:BlackLink .
+:linkc0_0c0s11a0l21 a craydict:BlackLink .
+:linkc0_0c0s11a0l22 a craydict:BlackLink .
+:linkc0_0c0s11a0l23 a craydict:BlackLink .
+:linkc0_0c0s11a0l30 a craydict:BlackLink .
+:linkc0_0c0s11a0l31 a craydict:BlackLink .
+:linkc0_0c0s11a0l32 a craydict:BlackLink .
+:linkc0_0c0s11a0l33 a craydict:BlackLink .
+:linkc0_0c0s11a0l40 a craydict:BlackLink .
+:linkc0_0c0s11a0l41 a craydict:BlackLink .
+:linkc0_0c0s11a0l42 a craydict:BlackLink .
+:linkc0_0c0s11a0l43 a craydict:BlackLink .
+:linkc0_0c0s11a0l50 a craydict:PtileLink .
+:linkc0_0c0s11a0l51 a craydict:PtileLink .
+:linkc0_0c0s11a0l52 a craydict:PtileLink .
+:linkc0_0c0s11a0l53 a craydict:PtileLink .
+:linkc0_0c0s11a0l54 a craydict:PtileLink .
+:linkc0_0c0s11a0l55 a craydict:PtileLink .
+:linkc0_0c0s11a0l56 a craydict:PtileLink .
+:linkc0_0c0s11a0l57 a craydict:PtileLink .
+:linkc0_0c0s1a0l00 a craydict:GreenLink .
+:linkc0_0c0s1a0l10 a craydict:GreenLink .
+:linkc0_0c0s1a0l11 a craydict:GreenLink .
+:linkc0_0c0s1a0l21 a craydict:GreenLink .
+:linkc0_0c0s1a0l22 a craydict:GreenLink .
+:linkc0_0c0s1a0l23 a craydict:GreenLink .
+:linkc0_0c0s1a0l24 a craydict:BlackLink .
+:linkc0_0c0s1a0l25 a craydict:BlackLink .
+:linkc0_0c0s1a0l26 a craydict:BlackLink .
+:linkc0_0c0s1a0l27 a craydict:BlackLink .
+:linkc0_0c0s1a0l30 a craydict:GreenLink .
+:linkc0_0c0s1a0l31 a craydict:GreenLink .
+:linkc0_0c0s1a0l34 a craydict:BlackLink .
+:linkc0_0c0s1a0l35 a craydict:BlackLink .
+:linkc0_0c0s1a0l36 a craydict:BlackLink .
+:linkc0_0c0s1a0l37 a craydict:BlackLink .
+:linkc0_0c0s1a0l41 a craydict:GreenLink .
+:linkc0_0c0s1a0l43 a craydict:GreenLink .
+:linkc0_0c0s1a0l44 a craydict:BlackLink .
+:linkc0_0c0s1a0l45 a craydict:BlackLink .
+:linkc0_0c0s1a0l46 a craydict:BlackLink .
+:linkc0_0c0s1a0l47 a craydict:BlackLink .
+:linkc0_0c0s1a0l50 a craydict:PtileLink .
+:linkc0_0c0s1a0l51 a craydict:PtileLink .
+:linkc0_0c0s1a0l52 a craydict:PtileLink .
+:linkc0_0c0s1a0l53 a craydict:PtileLink .
+:linkc0_0c0s1a0l54 a craydict:PtileLink .
+:linkc0_0c0s1a0l55 a craydict:PtileLink .
+:linkc0_0c0s1a0l56 a craydict:PtileLink .
+:linkc0_0c0s1a0l57 a craydict:PtileLink .
+:linkc0_0c0s2a0l00 a craydict:GreenLink .
+:linkc0_0c0s2a0l10 a craydict:GreenLink .
+:linkc0_0c0s2a0l11 a craydict:GreenLink .
+:linkc0_0c0s2a0l22 a craydict:GreenLink .
+:linkc0_0c0s2a0l23 a craydict:GreenLink .
+:linkc0_0c0s2a0l24 a craydict:BlackLink .
+:linkc0_0c0s2a0l25 a craydict:BlackLink .
+:linkc0_0c0s2a0l26 a craydict:BlackLink .
+:linkc0_0c0s2a0l27 a craydict:BlackLink .
+:linkc0_0c0s2a0l32 a craydict:GreenLink .
+:linkc0_0c0s2a0l33 a craydict:GreenLink .
+:linkc0_0c0s2a0l34 a craydict:BlackLink .
+:linkc0_0c0s2a0l35 a craydict:BlackLink .
+:linkc0_0c0s2a0l36 a craydict:BlackLink .
+:linkc0_0c0s2a0l37 a craydict:BlackLink .
+:linkc0_0c0s2a0l40 a craydict:GreenLink .
+:linkc0_0c0s2a0l41 a craydict:GreenLink .
+:linkc0_0c0s2a0l44 a craydict:BlackLink .
+:linkc0_0c0s2a0l45 a craydict:BlackLink .
+:linkc0_0c0s2a0l46 a craydict:BlackLink .
+:linkc0_0c0s2a0l47 a craydict:BlackLink .
+:linkc0_0c0s2a0l50 a craydict:PtileLink .
+:linkc0_0c0s2a0l51 a craydict:PtileLink .
+:linkc0_0c0s2a0l52 a craydict:PtileLink .
+:linkc0_0c0s2a0l53 a craydict:PtileLink .
+:linkc0_0c0s2a0l54 a craydict:PtileLink .
+:linkc0_0c0s2a0l55 a craydict:PtileLink .
+:linkc0_0c0s2a0l56 a craydict:PtileLink .
+:linkc0_0c0s2a0l57 a craydict:PtileLink .
+:linkc0_0c0s3a0l00 a craydict:GreenLink .
+:linkc0_0c0s3a0l10 a craydict:GreenLink .
+:linkc0_0c0s3a0l21 a craydict:GreenLink .
+:linkc0_0c0s3a0l23 a craydict:GreenLink .
+:linkc0_0c0s3a0l24 a craydict:BlackLink .
+:linkc0_0c0s3a0l25 a craydict:BlackLink .
+:linkc0_0c0s3a0l26 a craydict:BlackLink .
+:linkc0_0c0s3a0l27 a craydict:BlackLink .
+:linkc0_0c0s3a0l33 a craydict:GreenLink .
+:linkc0_0c0s3a0l34 a craydict:BlackLink .
+:linkc0_0c0s3a0l35 a craydict:BlackLink .
+:linkc0_0c0s3a0l36 a craydict:BlackLink .
+:linkc0_0c0s3a0l37 a craydict:BlackLink .
+:linkc0_0c0s3a0l40 a craydict:GreenLink .
+:linkc0_0c0s3a0l41 a craydict:GreenLink .
+:linkc0_0c0s3a0l43 a craydict:GreenLink .
+:linkc0_0c0s3a0l44 a craydict:BlackLink .
+:linkc0_0c0s3a0l45 a craydict:BlackLink .
+:linkc0_0c0s3a0l46 a craydict:BlackLink .
+:linkc0_0c0s3a0l47 a craydict:BlackLink .
+:linkc0_0c0s3a0l50 a craydict:PtileLink .
+:linkc0_0c0s3a0l51 a craydict:PtileLink .
+:linkc0_0c0s3a0l52 a craydict:PtileLink .
+:linkc0_0c0s3a0l53 a craydict:PtileLink .
+:linkc0_0c0s3a0l54 a craydict:PtileLink .
+:linkc0_0c0s3a0l55 a craydict:PtileLink .
+:linkc0_0c0s3a0l56 a craydict:PtileLink .
+:linkc0_0c0s3a0l57 a craydict:PtileLink .
+:linkc0_0c0s4a0l10 a craydict:GreenLink .
+:linkc0_0c0s4a0l21 a craydict:GreenLink .
+:linkc0_0c0s4a0l23 a craydict:GreenLink .
+:linkc0_0c0s4a0l24 a craydict:BlackLink .
+:linkc0_0c0s4a0l25 a craydict:BlackLink .
+:linkc0_0c0s4a0l26 a craydict:BlackLink .
+:linkc0_0c0s4a0l27 a craydict:BlackLink .
+:linkc0_0c0s4a0l30 a craydict:GreenLink .
+:linkc0_0c0s4a0l34 a craydict:BlackLink .
+:linkc0_0c0s4a0l35 a craydict:BlackLink .
+:linkc0_0c0s4a0l36 a craydict:BlackLink .
+:linkc0_0c0s4a0l37 a craydict:BlackLink .
+:linkc0_0c0s4a0l40 a craydict:GreenLink .
+:linkc0_0c0s4a0l41 a craydict:GreenLink .
+:linkc0_0c0s4a0l43 a craydict:GreenLink .
+:linkc0_0c0s4a0l44 a craydict:BlackLink .
+:linkc0_0c0s4a0l45 a craydict:BlackLink .
+:linkc0_0c0s4a0l46 a craydict:BlackLink .
+:linkc0_0c0s4a0l47 a craydict:BlackLink .
+:linkc0_0c0s4a0l50 a craydict:PtileLink .
+:linkc0_0c0s4a0l51 a craydict:PtileLink .
+:linkc0_0c0s4a0l52 a craydict:PtileLink .
+:linkc0_0c0s4a0l53 a craydict:PtileLink .
+:linkc0_0c0s4a0l54 a craydict:PtileLink .
+:linkc0_0c0s4a0l55 a craydict:PtileLink .
+:linkc0_0c0s4a0l56 a craydict:PtileLink .
+:linkc0_0c0s4a0l57 a craydict:PtileLink .
+:linkc0_0c0s5a0l22 a craydict:GreenLink .
+:linkc0_0c0s5a0l23 a craydict:GreenLink .
+:linkc0_0c0s5a0l24 a craydict:BlackLink .
+:linkc0_0c0s5a0l25 a craydict:BlackLink .
+:linkc0_0c0s5a0l26 a craydict:BlackLink .
+:linkc0_0c0s5a0l27 a craydict:BlackLink .
+:linkc0_0c0s5a0l32 a craydict:GreenLink .
+:linkc0_0c0s5a0l34 a craydict:BlackLink .
+:linkc0_0c0s5a0l37 a craydict:BlackLink .
+:linkc0_0c0s5a0l40 a craydict:GreenLink .
+:linkc0_0c0s5a0l41 a craydict:GreenLink .
+:linkc0_0c0s5a0l42 a craydict:GreenLink .
+:linkc0_0c0s5a0l44 a craydict:BlackLink .
+:linkc0_0c0s5a0l46 a craydict:BlackLink .
+:linkc0_0c0s5a0l47 a craydict:BlackLink .
+:linkc0_0c0s5a0l50 a craydict:PtileLink .
+:linkc0_0c0s5a0l51 a craydict:PtileLink .
+:linkc0_0c0s5a0l52 a craydict:PtileLink .
+:linkc0_0c0s5a0l53 a craydict:PtileLink .
+:linkc0_0c0s5a0l54 a craydict:PtileLink .
+:linkc0_0c0s5a0l55 a craydict:PtileLink .
+:linkc0_0c0s5a0l56 a craydict:PtileLink .
+:linkc0_0c0s5a0l57 a craydict:PtileLink .
+:linkc0_0c0s6a0l23 a craydict:GreenLink .
+:linkc0_0c0s6a0l24 a craydict:BlackLink .
+:linkc0_0c0s6a0l25 a craydict:BlackLink .
+:linkc0_0c0s6a0l26 a craydict:BlackLink .
+:linkc0_0c0s6a0l27 a craydict:BlackLink .
+:linkc0_0c0s6a0l30 a craydict:GreenLink .
+:linkc0_0c0s6a0l31 a craydict:GreenLink .
+:linkc0_0c0s6a0l34 a craydict:BlackLink .
+:linkc0_0c0s6a0l37 a craydict:BlackLink .
+:linkc0_0c0s6a0l41 a craydict:GreenLink .
+:linkc0_0c0s6a0l43 a craydict:GreenLink .
+:linkc0_0c0s6a0l44 a craydict:BlackLink .
+:linkc0_0c0s6a0l46 a craydict:BlackLink .
+:linkc0_0c0s6a0l47 a craydict:BlackLink .
+:linkc0_0c0s6a0l50 a craydict:PtileLink .
+:linkc0_0c0s6a0l51 a craydict:PtileLink .
+:linkc0_0c0s6a0l52 a craydict:PtileLink .
+:linkc0_0c0s6a0l53 a craydict:PtileLink .
+:linkc0_0c0s6a0l54 a craydict:PtileLink .
+:linkc0_0c0s6a0l55 a craydict:PtileLink .
+:linkc0_0c0s6a0l56 a craydict:PtileLink .
+:linkc0_0c0s6a0l57 a craydict:PtileLink .
+:linkc0_0c0s7a0l24 a craydict:BlackLink .
+:linkc0_0c0s7a0l25 a craydict:BlackLink .
+:linkc0_0c0s7a0l26 a craydict:BlackLink .
+:linkc0_0c0s7a0l27 a craydict:BlackLink .
+:linkc0_0c0s7a0l30 a craydict:GreenLink .
+:linkc0_0c0s7a0l34 a craydict:BlackLink .
+:linkc0_0c0s7a0l37 a craydict:BlackLink .
+:linkc0_0c0s7a0l40 a craydict:GreenLink .
+:linkc0_0c0s7a0l41 a craydict:GreenLink .
+:linkc0_0c0s7a0l42 a craydict:GreenLink .
+:linkc0_0c0s7a0l44 a craydict:BlackLink .
+:linkc0_0c0s7a0l46 a craydict:BlackLink .
+:linkc0_0c0s7a0l47 a craydict:BlackLink .
+:linkc0_0c0s7a0l50 a craydict:PtileLink .
+:linkc0_0c0s7a0l51 a craydict:PtileLink .
+:linkc0_0c0s7a0l52 a craydict:PtileLink .
+:linkc0_0c0s7a0l53 a craydict:PtileLink .
+:linkc0_0c0s7a0l54 a craydict:PtileLink .
+:linkc0_0c0s7a0l55 a craydict:PtileLink .
+:linkc0_0c0s7a0l56 a craydict:PtileLink .
+:linkc0_0c0s7a0l57 a craydict:PtileLink .
+:linkc0_0c0s8a0l17 a craydict:GreenLink .
+:linkc0_0c0s8a0l20 a craydict:BlackLink .
+:linkc0_0c0s8a0l21 a craydict:BlackLink .
+:linkc0_0c0s8a0l22 a craydict:BlackLink .
+:linkc0_0c0s8a0l23 a craydict:BlackLink .
+:linkc0_0c0s8a0l24 a craydict:GreenLink .
+:linkc0_0c0s8a0l26 a craydict:GreenLink .
+:linkc0_0c0s8a0l30 a craydict:BlackLink .
+:linkc0_0c0s8a0l31 a craydict:BlackLink .
+:linkc0_0c0s8a0l32 a craydict:BlackLink .
+:linkc0_0c0s8a0l33 a craydict:BlackLink .
+:linkc0_0c0s8a0l40 a craydict:BlackLink .
+:linkc0_0c0s8a0l41 a craydict:BlackLink .
+:linkc0_0c0s8a0l42 a craydict:BlackLink .
+:linkc0_0c0s8a0l43 a craydict:BlackLink .
+:linkc0_0c0s8a0l50 a craydict:PtileLink .
+:linkc0_0c0s8a0l51 a craydict:PtileLink .
+:linkc0_0c0s8a0l52 a craydict:PtileLink .
+:linkc0_0c0s8a0l53 a craydict:PtileLink .
+:linkc0_0c0s8a0l54 a craydict:PtileLink .
+:linkc0_0c0s8a0l55 a craydict:PtileLink .
+:linkc0_0c0s8a0l56 a craydict:PtileLink .
+:linkc0_0c0s8a0l57 a craydict:PtileLink .
+:linkc0_0c0s9a0l07 a craydict:GreenLink .
+:linkc0_0c0s9a0l20 a craydict:BlackLink .
+:linkc0_0c0s9a0l21 a craydict:BlackLink .
+:linkc0_0c0s9a0l22 a craydict:BlackLink .
+:linkc0_0c0s9a0l23 a craydict:BlackLink .
+:linkc0_0c0s9a0l24 a craydict:GreenLink .
+:linkc0_0c0s9a0l30 a craydict:BlackLink .
+:linkc0_0c0s9a0l31 a craydict:BlackLink .
+:linkc0_0c0s9a0l32 a craydict:BlackLink .
+:linkc0_0c0s9a0l33 a craydict:BlackLink .
+:linkc0_0c0s9a0l40 a craydict:BlackLink .
+:linkc0_0c0s9a0l41 a craydict:BlackLink .
+:linkc0_0c0s9a0l42 a craydict:BlackLink .
+:linkc0_0c0s9a0l43 a craydict:BlackLink .
+:linkc0_0c0s9a0l50 a craydict:PtileLink .
+:linkc0_0c0s9a0l51 a craydict:PtileLink .
+:linkc0_0c0s9a0l52 a craydict:PtileLink .
+:linkc0_0c0s9a0l53 a craydict:PtileLink .
+:linkc0_0c0s9a0l54 a craydict:PtileLink .
+:linkc0_0c0s9a0l55 a craydict:PtileLink .
+:linkc0_0c0s9a0l56 a craydict:PtileLink .
+:linkc0_0c0s9a0l57 a craydict:PtileLink .
+:linkc0_0c1s0a0l00 a craydict:GreenLink .
+:linkc0_0c1s0a0l07 a craydict:BlackLink .
+:linkc0_0c1s0a0l10 a craydict:GreenLink .
+:linkc0_0c1s0a0l11 a craydict:GreenLink .
+:linkc0_0c1s0a0l16 a craydict:BlackLink .
+:linkc0_0c1s0a0l17 a craydict:BlackLink .
+:linkc0_0c1s0a0l20 a craydict:GreenLink .
+:linkc0_0c1s0a0l21 a craydict:GreenLink .
+:linkc0_0c1s0a0l22 a craydict:GreenLink .
+:linkc0_0c1s0a0l23 a craydict:GreenLink .
+:linkc0_0c1s0a0l27 a craydict:BlackLink .
+:linkc0_0c1s0a0l30 a craydict:GreenLink .
+:linkc0_0c1s0a0l31 a craydict:GreenLink .
+:linkc0_0c1s0a0l32 a craydict:GreenLink .
+:linkc0_0c1s0a0l33 a craydict:GreenLink .
+:linkc0_0c1s0a0l34 a craydict:BlackLink .
+:linkc0_0c1s0a0l37 a craydict:BlackLink .
+:linkc0_0c1s0a0l40 a craydict:GreenLink .
+:linkc0_0c1s0a0l41 a craydict:GreenLink .
+:linkc0_0c1s0a0l42 a craydict:GreenLink .
+:linkc0_0c1s0a0l43 a craydict:GreenLink .
+:linkc0_0c1s0a0l44 a craydict:BlackLink .
+:linkc0_0c1s0a0l46 a craydict:BlackLink .
+:linkc0_0c1s0a0l47 a craydict:BlackLink .
+:linkc0_0c1s0a0l50 a craydict:PtileLink .
+:linkc0_0c1s0a0l51 a craydict:PtileLink .
+:linkc0_0c1s0a0l52 a craydict:PtileLink .
+:linkc0_0c1s0a0l53 a craydict:PtileLink .
+:linkc0_0c1s0a0l54 a craydict:PtileLink .
+:linkc0_0c1s0a0l55 a craydict:PtileLink .
+:linkc0_0c1s0a0l56 a craydict:PtileLink .
+:linkc0_0c1s0a0l57 a craydict:PtileLink .
+:linkc0_0c1s10a0l00 a craydict:BlackLink .
+:linkc0_0c1s10a0l07 a craydict:GreenLink .
+:linkc0_0c1s10a0l10 a craydict:BlackLink .
+:linkc0_0c1s10a0l11 a craydict:BlackLink .
+:linkc0_0c1s10a0l16 a craydict:GreenLink .
+:linkc0_0c1s10a0l17 a craydict:GreenLink .
+:linkc0_0c1s10a0l20 a craydict:BlackLink .
+:linkc0_0c1s10a0l24 a craydict:GreenLink .
+:linkc0_0c1s10a0l25 a craydict:GreenLink .
+:linkc0_0c1s10a0l30 a craydict:BlackLink .
+:linkc0_0c1s10a0l33 a craydict:BlackLink .
+:linkc0_0c1s10a0l40 a craydict:BlackLink .
+:linkc0_0c1s10a0l41 a craydict:BlackLink .
+:linkc0_0c1s10a0l43 a craydict:BlackLink .
+:linkc0_0c1s10a0l50 a craydict:PtileLink .
+:linkc0_0c1s10a0l51 a craydict:PtileLink .
+:linkc0_0c1s10a0l52 a craydict:PtileLink .
+:linkc0_0c1s10a0l53 a craydict:PtileLink .
+:linkc0_0c1s10a0l54 a craydict:PtileLink .
+:linkc0_0c1s10a0l55 a craydict:PtileLink .
+:linkc0_0c1s10a0l56 a craydict:PtileLink .
+:linkc0_0c1s10a0l57 a craydict:PtileLink .
+:linkc0_0c1s11a0l00 a craydict:BlackLink .
+:linkc0_0c1s11a0l07 a craydict:GreenLink .
+:linkc0_0c1s11a0l10 a craydict:BlackLink .
+:linkc0_0c1s11a0l11 a craydict:BlackLink .
+:linkc0_0c1s11a0l17 a craydict:GreenLink .
+:linkc0_0c1s11a0l20 a craydict:BlackLink .
+:linkc0_0c1s11a0l24 a craydict:GreenLink .
+:linkc0_0c1s11a0l26 a craydict:GreenLink .
+:linkc0_0c1s11a0l30 a craydict:BlackLink .
+:linkc0_0c1s11a0l33 a craydict:BlackLink .
+:linkc0_0c1s11a0l40 a craydict:BlackLink .
+:linkc0_0c1s11a0l41 a craydict:BlackLink .
+:linkc0_0c1s11a0l43 a craydict:BlackLink .
+:linkc0_0c1s11a0l50 a craydict:PtileLink .
+:linkc0_0c1s11a0l51 a craydict:PtileLink .
+:linkc0_0c1s11a0l52 a craydict:PtileLink .
+:linkc0_0c1s11a0l53 a craydict:PtileLink .
+:linkc0_0c1s11a0l54 a craydict:PtileLink .
+:linkc0_0c1s11a0l55 a craydict:PtileLink .
+:linkc0_0c1s11a0l56 a craydict:PtileLink .
+:linkc0_0c1s11a0l57 a craydict:PtileLink .
+:linkc0_0c1s12a0l00 a craydict:BlackLink .
+:linkc0_0c1s12a0l10 a craydict:BlackLink .
+:linkc0_0c1s12a0l11 a craydict:BlackLink .
+:linkc0_0c1s12a0l17 a craydict:GreenLink .
+:linkc0_0c1s12a0l20 a craydict:BlackLink .
+:linkc0_0c1s12a0l24 a craydict:GreenLink .
+:linkc0_0c1s12a0l26 a craydict:GreenLink .
+:linkc0_0c1s12a0l30 a craydict:BlackLink .
+:linkc0_0c1s12a0l33 a craydict:BlackLink .
+:linkc0_0c1s12a0l40 a craydict:BlackLink .
+:linkc0_0c1s12a0l41 a craydict:BlackLink .
+:linkc0_0c1s12a0l43 a craydict:BlackLink .
+:linkc0_0c1s12a0l50 a craydict:PtileLink .
+:linkc0_0c1s12a0l51 a craydict:PtileLink .
+:linkc0_0c1s12a0l52 a craydict:PtileLink .
+:linkc0_0c1s12a0l53 a craydict:PtileLink .
+:linkc0_0c1s12a0l54 a craydict:PtileLink .
+:linkc0_0c1s12a0l55 a craydict:PtileLink .
+:linkc0_0c1s12a0l56 a craydict:PtileLink .
+:linkc0_0c1s12a0l57 a craydict:PtileLink .
+:linkc0_0c1s13a0l00 a craydict:BlackLink .
+:linkc0_0c1s13a0l10 a craydict:BlackLink .
+:linkc0_0c1s13a0l11 a craydict:BlackLink .
+:linkc0_0c1s13a0l20 a craydict:BlackLink .
+:linkc0_0c1s13a0l24 a craydict:GreenLink .
+:linkc0_0c1s13a0l25 a craydict:GreenLink .
+:linkc0_0c1s13a0l33 a craydict:BlackLink .
+:linkc0_0c1s13a0l43 a craydict:BlackLink .
+:linkc0_0c1s13a0l50 a craydict:PtileLink .
+:linkc0_0c1s13a0l51 a craydict:PtileLink .
+:linkc0_0c1s13a0l52 a craydict:PtileLink .
+:linkc0_0c1s13a0l53 a craydict:PtileLink .
+:linkc0_0c1s13a0l54 a craydict:PtileLink .
+:linkc0_0c1s13a0l55 a craydict:PtileLink .
+:linkc0_0c1s13a0l56 a craydict:PtileLink .
+:linkc0_0c1s13a0l57 a craydict:PtileLink .
+:linkc0_0c1s14a0l00 a craydict:BlackLink .
+:linkc0_0c1s14a0l10 a craydict:BlackLink .
+:linkc0_0c1s14a0l11 a craydict:BlackLink .
+:linkc0_0c1s14a0l24 a craydict:GreenLink .
+:linkc0_0c1s14a0l50 a craydict:PtileLink .
+:linkc0_0c1s14a0l51 a craydict:PtileLink .
+:linkc0_0c1s14a0l52 a craydict:PtileLink .
+:linkc0_0c1s14a0l53 a craydict:PtileLink .
+:linkc0_0c1s14a0l54 a craydict:PtileLink .
+:linkc0_0c1s14a0l55 a craydict:PtileLink .
+:linkc0_0c1s14a0l56 a craydict:PtileLink .
+:linkc0_0c1s14a0l57 a craydict:PtileLink .
+:linkc0_0c1s15a0l00 a craydict:BlackLink .
+:linkc0_0c1s15a0l10 a craydict:BlackLink .
+:linkc0_0c1s15a0l11 a craydict:BlackLink .
+:linkc0_0c1s15a0l50 a craydict:PtileLink .
+:linkc0_0c1s15a0l51 a craydict:PtileLink .
+:linkc0_0c1s15a0l52 a craydict:PtileLink .
+:linkc0_0c1s15a0l53 a craydict:PtileLink .
+:linkc0_0c1s15a0l54 a craydict:PtileLink .
+:linkc0_0c1s15a0l55 a craydict:PtileLink .
+:linkc0_0c1s15a0l56 a craydict:PtileLink .
+:linkc0_0c1s15a0l57 a craydict:PtileLink .
+:linkc0_0c1s1a0l00 a craydict:GreenLink .
+:linkc0_0c1s1a0l07 a craydict:BlackLink .
+:linkc0_0c1s1a0l10 a craydict:GreenLink .
+:linkc0_0c1s1a0l11 a craydict:GreenLink .
+:linkc0_0c1s1a0l16 a craydict:BlackLink .
+:linkc0_0c1s1a0l17 a craydict:BlackLink .
+:linkc0_0c1s1a0l21 a craydict:GreenLink .
+:linkc0_0c1s1a0l22 a craydict:GreenLink .
+:linkc0_0c1s1a0l23 a craydict:GreenLink .
+:linkc0_0c1s1a0l27 a craydict:BlackLink .
+:linkc0_0c1s1a0l30 a craydict:GreenLink .
+:linkc0_0c1s1a0l31 a craydict:GreenLink .
+:linkc0_0c1s1a0l32 a craydict:GreenLink .
+:linkc0_0c1s1a0l33 a craydict:GreenLink .
+:linkc0_0c1s1a0l34 a craydict:BlackLink .
+:linkc0_0c1s1a0l37 a craydict:BlackLink .
+:linkc0_0c1s1a0l40 a craydict:GreenLink .
+:linkc0_0c1s1a0l41 a craydict:GreenLink .
+:linkc0_0c1s1a0l42 a craydict:GreenLink .
+:linkc0_0c1s1a0l43 a craydict:GreenLink .
+:linkc0_0c1s1a0l44 a craydict:BlackLink .
+:linkc0_0c1s1a0l46 a craydict:BlackLink .
+:linkc0_0c1s1a0l47 a craydict:BlackLink .
+:linkc0_0c1s1a0l50 a craydict:PtileLink .
+:linkc0_0c1s1a0l51 a craydict:PtileLink .
+:linkc0_0c1s1a0l52 a craydict:PtileLink .
+:linkc0_0c1s1a0l53 a craydict:PtileLink .
+:linkc0_0c1s1a0l54 a craydict:PtileLink .
+:linkc0_0c1s1a0l55 a craydict:PtileLink .
+:linkc0_0c1s1a0l56 a craydict:PtileLink .
+:linkc0_0c1s1a0l57 a craydict:PtileLink .
+:linkc0_0c1s2a0l00 a craydict:GreenLink .
+:linkc0_0c1s2a0l07 a craydict:BlackLink .
+:linkc0_0c1s2a0l10 a craydict:GreenLink .
+:linkc0_0c1s2a0l11 a craydict:GreenLink .
+:linkc0_0c1s2a0l16 a craydict:BlackLink .
+:linkc0_0c1s2a0l17 a craydict:BlackLink .
+:linkc0_0c1s2a0l22 a craydict:GreenLink .
+:linkc0_0c1s2a0l23 a craydict:GreenLink .
+:linkc0_0c1s2a0l27 a craydict:BlackLink .
+:linkc0_0c1s2a0l30 a craydict:GreenLink .
+:linkc0_0c1s2a0l31 a craydict:GreenLink .
+:linkc0_0c1s2a0l32 a craydict:GreenLink .
+:linkc0_0c1s2a0l33 a craydict:GreenLink .
+:linkc0_0c1s2a0l34 a craydict:BlackLink .
+:linkc0_0c1s2a0l37 a craydict:BlackLink .
+:linkc0_0c1s2a0l40 a craydict:GreenLink .
+:linkc0_0c1s2a0l41 a craydict:GreenLink .
+:linkc0_0c1s2a0l42 a craydict:GreenLink .
+:linkc0_0c1s2a0l43 a craydict:GreenLink .
+:linkc0_0c1s2a0l44 a craydict:BlackLink .
+:linkc0_0c1s2a0l46 a craydict:BlackLink .
+:linkc0_0c1s2a0l47 a craydict:BlackLink .
+:linkc0_0c1s2a0l50 a craydict:PtileLink .
+:linkc0_0c1s2a0l51 a craydict:PtileLink .
+:linkc0_0c1s2a0l52 a craydict:PtileLink .
+:linkc0_0c1s2a0l53 a craydict:PtileLink .
+:linkc0_0c1s2a0l54 a craydict:PtileLink .
+:linkc0_0c1s2a0l55 a craydict:PtileLink .
+:linkc0_0c1s2a0l56 a craydict:PtileLink .
+:linkc0_0c1s2a0l57 a craydict:PtileLink .
+:linkc0_0c1s3a0l00 a craydict:GreenLink .
+:linkc0_0c1s3a0l07 a craydict:BlackLink .
+:linkc0_0c1s3a0l10 a craydict:GreenLink .
+:linkc0_0c1s3a0l16 a craydict:BlackLink .
+:linkc0_0c1s3a0l17 a craydict:BlackLink .
+:linkc0_0c1s3a0l21 a craydict:GreenLink .
+:linkc0_0c1s3a0l23 a craydict:GreenLink .
+:linkc0_0c1s3a0l27 a craydict:BlackLink .
+:linkc0_0c1s3a0l30 a craydict:GreenLink .
+:linkc0_0c1s3a0l31 a craydict:GreenLink .
+:linkc0_0c1s3a0l32 a craydict:GreenLink .
+:linkc0_0c1s3a0l33 a craydict:GreenLink .
+:linkc0_0c1s3a0l34 a craydict:BlackLink .
+:linkc0_0c1s3a0l37 a craydict:BlackLink .
+:linkc0_0c1s3a0l40 a craydict:GreenLink .
+:linkc0_0c1s3a0l41 a craydict:GreenLink .
+:linkc0_0c1s3a0l42 a craydict:GreenLink .
+:linkc0_0c1s3a0l43 a craydict:GreenLink .
+:linkc0_0c1s3a0l44 a craydict:BlackLink .
+:linkc0_0c1s3a0l46 a craydict:BlackLink .
+:linkc0_0c1s3a0l47 a craydict:BlackLink .
+:linkc0_0c1s3a0l50 a craydict:PtileLink .
+:linkc0_0c1s3a0l51 a craydict:PtileLink .
+:linkc0_0c1s3a0l52 a craydict:PtileLink .
+:linkc0_0c1s3a0l53 a craydict:PtileLink .
+:linkc0_0c1s3a0l54 a craydict:PtileLink .
+:linkc0_0c1s3a0l55 a craydict:PtileLink .
+:linkc0_0c1s3a0l56 a craydict:PtileLink .
+:linkc0_0c1s3a0l57 a craydict:PtileLink .
+:linkc0_0c1s4a0l07 a craydict:BlackLink .
+:linkc0_0c1s4a0l10 a craydict:GreenLink .
+:linkc0_0c1s4a0l16 a craydict:BlackLink .
+:linkc0_0c1s4a0l17 a craydict:BlackLink .
+:linkc0_0c1s4a0l21 a craydict:GreenLink .
+:linkc0_0c1s4a0l23 a craydict:GreenLink .
+:linkc0_0c1s4a0l27 a craydict:BlackLink .
+:linkc0_0c1s4a0l30 a craydict:GreenLink .
+:linkc0_0c1s4a0l31 a craydict:GreenLink .
+:linkc0_0c1s4a0l32 a craydict:GreenLink .
+:linkc0_0c1s4a0l33 a craydict:GreenLink .
+:linkc0_0c1s4a0l34 a craydict:BlackLink .
+:linkc0_0c1s4a0l37 a craydict:BlackLink .
+:linkc0_0c1s4a0l40 a craydict:GreenLink .
+:linkc0_0c1s4a0l41 a craydict:GreenLink .
+:linkc0_0c1s4a0l42 a craydict:GreenLink .
+:linkc0_0c1s4a0l43 a craydict:GreenLink .
+:linkc0_0c1s4a0l44 a craydict:BlackLink .
+:linkc0_0c1s4a0l46 a craydict:BlackLink .
+:linkc0_0c1s4a0l47 a craydict:BlackLink .
+:linkc0_0c1s4a0l50 a craydict:PtileLink .
+:linkc0_0c1s4a0l51 a craydict:PtileLink .
+:linkc0_0c1s4a0l52 a craydict:PtileLink .
+:linkc0_0c1s4a0l53 a craydict:PtileLink .
+:linkc0_0c1s4a0l54 a craydict:PtileLink .
+:linkc0_0c1s4a0l55 a craydict:PtileLink .
+:linkc0_0c1s4a0l56 a craydict:PtileLink .
+:linkc0_0c1s4a0l57 a craydict:PtileLink .
+:linkc0_0c1s5a0l07 a craydict:BlackLink .
+:linkc0_0c1s5a0l16 a craydict:BlackLink .
+:linkc0_0c1s5a0l17 a craydict:BlackLink .
+:linkc0_0c1s5a0l22 a craydict:GreenLink .
+:linkc0_0c1s5a0l23 a craydict:GreenLink .
+:linkc0_0c1s5a0l27 a craydict:BlackLink .
+:linkc0_0c1s5a0l30 a craydict:GreenLink .
+:linkc0_0c1s5a0l31 a craydict:GreenLink .
+:linkc0_0c1s5a0l32 a craydict:GreenLink .
+:linkc0_0c1s5a0l33 a craydict:GreenLink .
+:linkc0_0c1s5a0l34 a craydict:BlackLink .
+:linkc0_0c1s5a0l40 a craydict:GreenLink .
+:linkc0_0c1s5a0l41 a craydict:GreenLink .
+:linkc0_0c1s5a0l42 a craydict:GreenLink .
+:linkc0_0c1s5a0l43 a craydict:GreenLink .
+:linkc0_0c1s5a0l44 a craydict:BlackLink .
+:linkc0_0c1s5a0l50 a craydict:PtileLink .
+:linkc0_0c1s5a0l51 a craydict:PtileLink .
+:linkc0_0c1s5a0l52 a craydict:PtileLink .
+:linkc0_0c1s5a0l53 a craydict:PtileLink .
+:linkc0_0c1s5a0l54 a craydict:PtileLink .
+:linkc0_0c1s5a0l55 a craydict:PtileLink .
+:linkc0_0c1s5a0l56 a craydict:PtileLink .
+:linkc0_0c1s5a0l57 a craydict:PtileLink .
+:linkc0_0c1s6a0l07 a craydict:BlackLink .
+:linkc0_0c1s6a0l16 a craydict:BlackLink .
+:linkc0_0c1s6a0l17 a craydict:BlackLink .
+:linkc0_0c1s6a0l23 a craydict:GreenLink .
+:linkc0_0c1s6a0l27 a craydict:BlackLink .
+:linkc0_0c1s6a0l30 a craydict:GreenLink .
+:linkc0_0c1s6a0l31 a craydict:GreenLink .
+:linkc0_0c1s6a0l32 a craydict:GreenLink .
+:linkc0_0c1s6a0l33 a craydict:GreenLink .
+:linkc0_0c1s6a0l34 a craydict:BlackLink .
+:linkc0_0c1s6a0l40 a craydict:GreenLink .
+:linkc0_0c1s6a0l41 a craydict:GreenLink .
+:linkc0_0c1s6a0l42 a craydict:GreenLink .
+:linkc0_0c1s6a0l43 a craydict:GreenLink .
+:linkc0_0c1s6a0l44 a craydict:BlackLink .
+:linkc0_0c1s6a0l50 a craydict:PtileLink .
+:linkc0_0c1s6a0l51 a craydict:PtileLink .
+:linkc0_0c1s6a0l52 a craydict:PtileLink .
+:linkc0_0c1s6a0l53 a craydict:PtileLink .
+:linkc0_0c1s6a0l54 a craydict:PtileLink .
+:linkc0_0c1s6a0l55 a craydict:PtileLink .
+:linkc0_0c1s6a0l56 a craydict:PtileLink .
+:linkc0_0c1s6a0l57 a craydict:PtileLink .
+:linkc0_0c1s7a0l07 a craydict:BlackLink .
+:linkc0_0c1s7a0l16 a craydict:BlackLink .
+:linkc0_0c1s7a0l17 a craydict:BlackLink .
+:linkc0_0c1s7a0l27 a craydict:BlackLink .
+:linkc0_0c1s7a0l30 a craydict:GreenLink .
+:linkc0_0c1s7a0l31 a craydict:GreenLink .
+:linkc0_0c1s7a0l32 a craydict:GreenLink .
+:linkc0_0c1s7a0l33 a craydict:GreenLink .
+:linkc0_0c1s7a0l34 a craydict:BlackLink .
+:linkc0_0c1s7a0l40 a craydict:GreenLink .
+:linkc0_0c1s7a0l41 a craydict:GreenLink .
+:linkc0_0c1s7a0l42 a craydict:GreenLink .
+:linkc0_0c1s7a0l43 a craydict:GreenLink .
+:linkc0_0c1s7a0l44 a craydict:BlackLink .
+:linkc0_0c1s7a0l50 a craydict:PtileLink .
+:linkc0_0c1s7a0l51 a craydict:PtileLink .
+:linkc0_0c1s7a0l52 a craydict:PtileLink .
+:linkc0_0c1s7a0l53 a craydict:PtileLink .
+:linkc0_0c1s7a0l54 a craydict:PtileLink .
+:linkc0_0c1s7a0l55 a craydict:PtileLink .
+:linkc0_0c1s7a0l56 a craydict:PtileLink .
+:linkc0_0c1s7a0l57 a craydict:PtileLink .
+:linkc0_0c1s8a0l00 a craydict:BlackLink .
+:linkc0_0c1s8a0l07 a craydict:GreenLink .
+:linkc0_0c1s8a0l10 a craydict:BlackLink .
+:linkc0_0c1s8a0l11 a craydict:BlackLink .
+:linkc0_0c1s8a0l16 a craydict:GreenLink .
+:linkc0_0c1s8a0l17 a craydict:GreenLink .
+:linkc0_0c1s8a0l20 a craydict:BlackLink .
+:linkc0_0c1s8a0l24 a craydict:GreenLink .
+:linkc0_0c1s8a0l25 a craydict:GreenLink .
+:linkc0_0c1s8a0l26 a craydict:GreenLink .
+:linkc0_0c1s8a0l27 a craydict:GreenLink .
+:linkc0_0c1s8a0l30 a craydict:BlackLink .
+:linkc0_0c1s8a0l33 a craydict:BlackLink .
+:linkc0_0c1s8a0l40 a craydict:BlackLink .
+:linkc0_0c1s8a0l41 a craydict:BlackLink .
+:linkc0_0c1s8a0l43 a craydict:BlackLink .
+:linkc0_0c1s8a0l50 a craydict:PtileLink .
+:linkc0_0c1s8a0l51 a craydict:PtileLink .
+:linkc0_0c1s8a0l52 a craydict:PtileLink .
+:linkc0_0c1s8a0l53 a craydict:PtileLink .
+:linkc0_0c1s8a0l54 a craydict:PtileLink .
+:linkc0_0c1s8a0l55 a craydict:PtileLink .
+:linkc0_0c1s8a0l56 a craydict:PtileLink .
+:linkc0_0c1s8a0l57 a craydict:PtileLink .
+:linkc0_0c1s9a0l00 a craydict:BlackLink .
+:linkc0_0c1s9a0l07 a craydict:GreenLink .
+:linkc0_0c1s9a0l10 a craydict:BlackLink .
+:linkc0_0c1s9a0l11 a craydict:BlackLink .
+:linkc0_0c1s9a0l16 a craydict:GreenLink .
+:linkc0_0c1s9a0l17 a craydict:GreenLink .
+:linkc0_0c1s9a0l20 a craydict:BlackLink .
+:linkc0_0c1s9a0l24 a craydict:GreenLink .
+:linkc0_0c1s9a0l25 a craydict:GreenLink .
+:linkc0_0c1s9a0l26 a craydict:GreenLink .
+:linkc0_0c1s9a0l30 a craydict:BlackLink .
+:linkc0_0c1s9a0l33 a craydict:BlackLink .
+:linkc0_0c1s9a0l40 a craydict:BlackLink .
+:linkc0_0c1s9a0l41 a craydict:BlackLink .
+:linkc0_0c1s9a0l43 a craydict:BlackLink .
+:linkc0_0c1s9a0l50 a craydict:PtileLink .
+:linkc0_0c1s9a0l51 a craydict:PtileLink .
+:linkc0_0c1s9a0l52 a craydict:PtileLink .
+:linkc0_0c1s9a0l53 a craydict:PtileLink .
+:linkc0_0c1s9a0l54 a craydict:PtileLink .
+:linkc0_0c1s9a0l55 a craydict:PtileLink .
+:linkc0_0c1s9a0l56 a craydict:PtileLink .
+:linkc0_0c1s9a0l57 a craydict:PtileLink .
+:linkc0_0c2s0a0l07 a craydict:BlackLink .
+:linkc0_0c2s0a0l10 a craydict:GreenLink .
+:linkc0_0c2s0a0l16 a craydict:BlackLink .
+:linkc0_0c2s0a0l17 a craydict:BlackLink .
+:linkc0_0c2s0a0l20 a craydict:GreenLink .
+:linkc0_0c2s0a0l21 a craydict:GreenLink .
+:linkc0_0c2s0a0l23 a craydict:GreenLink .
+:linkc0_0c2s0a0l24 a craydict:BlackLink .
+:linkc0_0c2s0a0l25 a craydict:BlackLink .
+:linkc0_0c2s0a0l26 a craydict:BlackLink .
+:linkc0_0c2s0a0l30 a craydict:GreenLink .
+:linkc0_0c2s0a0l31 a craydict:GreenLink .
+:linkc0_0c2s0a0l32 a craydict:GreenLink .
+:linkc0_0c2s0a0l33 a craydict:GreenLink .
+:linkc0_0c2s0a0l43 a craydict:GreenLink .
+:linkc0_0c2s0a0l50 a craydict:PtileLink .
+:linkc0_0c2s0a0l51 a craydict:PtileLink .
+:linkc0_0c2s0a0l52 a craydict:PtileLink .
+:linkc0_0c2s0a0l53 a craydict:PtileLink .
+:linkc0_0c2s0a0l54 a craydict:PtileLink .
+:linkc0_0c2s0a0l55 a craydict:PtileLink .
+:linkc0_0c2s0a0l56 a craydict:PtileLink .
+:linkc0_0c2s0a0l57 a craydict:PtileLink .
+:linkc0_0c2s10a0l00 a craydict:BlackLink .
+:linkc0_0c2s10a0l10 a craydict:BlackLink .
+:linkc0_0c2s10a0l11 a craydict:BlackLink .
+:linkc0_0c2s10a0l16 a craydict:GreenLink .
+:linkc0_0c2s10a0l21 a craydict:BlackLink .
+:linkc0_0c2s10a0l22 a craydict:BlackLink .
+:linkc0_0c2s10a0l23 a craydict:BlackLink .
+:linkc0_0c2s10a0l24 a craydict:GreenLink .
+:linkc0_0c2s10a0l50 a craydict:PtileLink .
+:linkc0_0c2s10a0l51 a craydict:PtileLink .
+:linkc0_0c2s10a0l52 a craydict:PtileLink .
+:linkc0_0c2s10a0l53 a craydict:PtileLink .
+:linkc0_0c2s10a0l54 a craydict:PtileLink .
+:linkc0_0c2s10a0l55 a craydict:PtileLink .
+:linkc0_0c2s10a0l56 a craydict:PtileLink .
+:linkc0_0c2s10a0l57 a craydict:PtileLink .
+:linkc0_0c2s11a0l00 a craydict:BlackLink .
+:linkc0_0c2s11a0l10 a craydict:BlackLink .
+:linkc0_0c2s11a0l11 a craydict:BlackLink .
+:linkc0_0c2s11a0l21 a craydict:BlackLink .
+:linkc0_0c2s11a0l22 a craydict:BlackLink .
+:linkc0_0c2s11a0l23 a craydict:BlackLink .
+:linkc0_0c2s11a0l24 a craydict:GreenLink .
+:linkc0_0c2s11a0l50 a craydict:PtileLink .
+:linkc0_0c2s11a0l51 a craydict:PtileLink .
+:linkc0_0c2s11a0l52 a craydict:PtileLink .
+:linkc0_0c2s11a0l53 a craydict:PtileLink .
+:linkc0_0c2s11a0l54 a craydict:PtileLink .
+:linkc0_0c2s11a0l55 a craydict:PtileLink .
+:linkc0_0c2s11a0l56 a craydict:PtileLink .
+:linkc0_0c2s11a0l57 a craydict:PtileLink .
+:linkc0_0c2s12a0l00 a craydict:BlackLink .
+:linkc0_0c2s12a0l10 a craydict:BlackLink .
+:linkc0_0c2s12a0l11 a craydict:BlackLink .
+:linkc0_0c2s12a0l21 a craydict:BlackLink .
+:linkc0_0c2s12a0l22 a craydict:BlackLink .
+:linkc0_0c2s12a0l23 a craydict:BlackLink .
+:linkc0_0c2s12a0l50 a craydict:PtileLink .
+:linkc0_0c2s12a0l51 a craydict:PtileLink .
+:linkc0_0c2s12a0l52 a craydict:PtileLink .
+:linkc0_0c2s12a0l53 a craydict:PtileLink .
+:linkc0_0c2s12a0l54 a craydict:PtileLink .
+:linkc0_0c2s12a0l55 a craydict:PtileLink .
+:linkc0_0c2s12a0l56 a craydict:PtileLink .
+:linkc0_0c2s12a0l57 a craydict:PtileLink .
+:linkc0_0c2s1a0l00 a craydict:GreenLink .
+:linkc0_0c2s1a0l07 a craydict:BlackLink .
+:linkc0_0c2s1a0l16 a craydict:BlackLink .
+:linkc0_0c2s1a0l17 a craydict:BlackLink .
+:linkc0_0c2s1a0l21 a craydict:GreenLink .
+:linkc0_0c2s1a0l23 a craydict:GreenLink .
+:linkc0_0c2s1a0l24 a craydict:BlackLink .
+:linkc0_0c2s1a0l25 a craydict:BlackLink .
+:linkc0_0c2s1a0l26 a craydict:BlackLink .
+:linkc0_0c2s1a0l30 a craydict:GreenLink .
+:linkc0_0c2s1a0l31 a craydict:GreenLink .
+:linkc0_0c2s1a0l41 a craydict:GreenLink .
+:linkc0_0c2s1a0l42 a craydict:GreenLink .
+:linkc0_0c2s1a0l43 a craydict:GreenLink .
+:linkc0_0c2s1a0l50 a craydict:PtileLink .
+:linkc0_0c2s1a0l51 a craydict:PtileLink .
+:linkc0_0c2s1a0l52 a craydict:PtileLink .
+:linkc0_0c2s1a0l53 a craydict:PtileLink .
+:linkc0_0c2s1a0l54 a craydict:PtileLink .
+:linkc0_0c2s1a0l55 a craydict:PtileLink .
+:linkc0_0c2s1a0l56 a craydict:PtileLink .
+:linkc0_0c2s1a0l57 a craydict:PtileLink .
+:linkc0_0c2s2a0l07 a craydict:BlackLink .
+:linkc0_0c2s2a0l11 a craydict:GreenLink .
+:linkc0_0c2s2a0l16 a craydict:BlackLink .
+:linkc0_0c2s2a0l17 a craydict:BlackLink .
+:linkc0_0c2s2a0l23 a craydict:GreenLink .
+:linkc0_0c2s2a0l24 a craydict:BlackLink .
+:linkc0_0c2s2a0l25 a craydict:BlackLink .
+:linkc0_0c2s2a0l26 a craydict:BlackLink .
+:linkc0_0c2s2a0l31 a craydict:GreenLink .
+:linkc0_0c2s2a0l32 a craydict:GreenLink .
+:linkc0_0c2s2a0l33 a craydict:GreenLink .
+:linkc0_0c2s2a0l40 a craydict:GreenLink .
+:linkc0_0c2s2a0l41 a craydict:GreenLink .
+:linkc0_0c2s2a0l50 a craydict:PtileLink .
+:linkc0_0c2s2a0l51 a craydict:PtileLink .
+:linkc0_0c2s2a0l52 a craydict:PtileLink .
+:linkc0_0c2s2a0l53 a craydict:PtileLink .
+:linkc0_0c2s2a0l54 a craydict:PtileLink .
+:linkc0_0c2s2a0l55 a craydict:PtileLink .
+:linkc0_0c2s2a0l56 a craydict:PtileLink .
+:linkc0_0c2s2a0l57 a craydict:PtileLink .
+:linkc0_0c2s3a0l07 a craydict:BlackLink .
+:linkc0_0c2s3a0l16 a craydict:BlackLink .
+:linkc0_0c2s3a0l17 a craydict:BlackLink .
+:linkc0_0c2s3a0l23 a craydict:GreenLink .
+:linkc0_0c2s3a0l24 a craydict:BlackLink .
+:linkc0_0c2s3a0l25 a craydict:BlackLink .
+:linkc0_0c2s3a0l26 a craydict:BlackLink .
+:linkc0_0c2s3a0l31 a craydict:GreenLink .
+:linkc0_0c2s3a0l33 a craydict:GreenLink .
+:linkc0_0c2s3a0l40 a craydict:GreenLink .
+:linkc0_0c2s3a0l41 a craydict:GreenLink .
+:linkc0_0c2s3a0l43 a craydict:GreenLink .
+:linkc0_0c2s3a0l50 a craydict:PtileLink .
+:linkc0_0c2s3a0l51 a craydict:PtileLink .
+:linkc0_0c2s3a0l52 a craydict:PtileLink .
+:linkc0_0c2s3a0l53 a craydict:PtileLink .
+:linkc0_0c2s3a0l54 a craydict:PtileLink .
+:linkc0_0c2s3a0l55 a craydict:PtileLink .
+:linkc0_0c2s3a0l56 a craydict:PtileLink .
+:linkc0_0c2s3a0l57 a craydict:PtileLink .
+:linkc0_0c2s4a0l07 a craydict:BlackLink .
+:linkc0_0c2s4a0l16 a craydict:BlackLink .
+:linkc0_0c2s4a0l17 a craydict:BlackLink .
+:linkc0_0c2s4a0l24 a craydict:BlackLink .
+:linkc0_0c2s4a0l25 a craydict:BlackLink .
+:linkc0_0c2s4a0l26 a craydict:BlackLink .
+:linkc0_0c2s4a0l30 a craydict:GreenLink .
+:linkc0_0c2s4a0l32 a craydict:GreenLink .
+:linkc0_0c2s4a0l40 a craydict:GreenLink .
+:linkc0_0c2s4a0l41 a craydict:GreenLink .
+:linkc0_0c2s4a0l43 a craydict:GreenLink .
+:linkc0_0c2s4a0l50 a craydict:PtileLink .
+:linkc0_0c2s4a0l51 a craydict:PtileLink .
+:linkc0_0c2s4a0l52 a craydict:PtileLink .
+:linkc0_0c2s4a0l53 a craydict:PtileLink .
+:linkc0_0c2s4a0l54 a craydict:PtileLink .
+:linkc0_0c2s4a0l55 a craydict:PtileLink .
+:linkc0_0c2s4a0l56 a craydict:PtileLink .
+:linkc0_0c2s4a0l57 a craydict:PtileLink .
+:linkc0_0c2s8a0l00 a craydict:BlackLink .
+:linkc0_0c2s8a0l10 a craydict:BlackLink .
+:linkc0_0c2s8a0l11 a craydict:BlackLink .
+:linkc0_0c2s8a0l17 a craydict:GreenLink .
+:linkc0_0c2s8a0l21 a craydict:BlackLink .
+:linkc0_0c2s8a0l22 a craydict:BlackLink .
+:linkc0_0c2s8a0l23 a craydict:BlackLink .
+:linkc0_0c2s8a0l24 a craydict:GreenLink .
+:linkc0_0c2s8a0l26 a craydict:GreenLink .
+:linkc0_0c2s8a0l27 a craydict:GreenLink .
+:linkc0_0c2s8a0l50 a craydict:PtileLink .
+:linkc0_0c2s8a0l51 a craydict:PtileLink .
+:linkc0_0c2s8a0l52 a craydict:PtileLink .
+:linkc0_0c2s8a0l53 a craydict:PtileLink .
+:linkc0_0c2s8a0l54 a craydict:PtileLink .
+:linkc0_0c2s8a0l55 a craydict:PtileLink .
+:linkc0_0c2s8a0l56 a craydict:PtileLink .
+:linkc0_0c2s8a0l57 a craydict:PtileLink .
+:linkc0_0c2s9a0l00 a craydict:BlackLink .
+:linkc0_0c2s9a0l07 a craydict:GreenLink .
+:linkc0_0c2s9a0l10 a craydict:BlackLink .
+:linkc0_0c2s9a0l11 a craydict:BlackLink .
+:linkc0_0c2s9a0l21 a craydict:BlackLink .
+:linkc0_0c2s9a0l22 a craydict:BlackLink .
+:linkc0_0c2s9a0l23 a craydict:BlackLink .
+:linkc0_0c2s9a0l24 a craydict:GreenLink .
+:linkc0_0c2s9a0l26 a craydict:GreenLink .
+:linkc0_0c2s9a0l50 a craydict:PtileLink .
+:linkc0_0c2s9a0l51 a craydict:PtileLink .
+:linkc0_0c2s9a0l52 a craydict:PtileLink .
+:linkc0_0c2s9a0l53 a craydict:PtileLink .
+:linkc0_0c2s9a0l54 a craydict:PtileLink .
+:linkc0_0c2s9a0l55 a craydict:PtileLink .
+:linkc0_0c2s9a0l56 a craydict:PtileLink .
+:linkc0_0c2s9a0l57 a craydict:PtileLink .
+:linkc1_0c0s0a0l00 a craydict:GreenLink .
+:linkc1_0c0s0a0l10 a craydict:GreenLink .
+:linkc1_0c0s0a0l11 a craydict:GreenLink .
+:linkc1_0c0s0a0l20 a craydict:GreenLink .
+:linkc1_0c0s0a0l21 a craydict:GreenLink .
+:linkc1_0c0s0a0l22 a craydict:GreenLink .
+:linkc1_0c0s0a0l23 a craydict:GreenLink .
+:linkc1_0c0s0a0l30 a craydict:GreenLink .
+:linkc1_0c0s0a0l31 a craydict:GreenLink .
+:linkc1_0c0s0a0l32 a craydict:GreenLink .
+:linkc1_0c0s0a0l33 a craydict:GreenLink .
+:linkc1_0c0s0a0l37 a craydict:BlackLink .
+:linkc1_0c0s0a0l40 a craydict:GreenLink .
+:linkc1_0c0s0a0l41 a craydict:GreenLink .
+:linkc1_0c0s0a0l42 a craydict:GreenLink .
+:linkc1_0c0s0a0l43 a craydict:GreenLink .
+:linkc1_0c0s0a0l46 a craydict:BlackLink .
+:linkc1_0c0s0a0l47 a craydict:BlackLink .
+:linkc1_0c0s0a0l50 a craydict:PtileLink .
+:linkc1_0c0s0a0l51 a craydict:PtileLink .
+:linkc1_0c0s0a0l52 a craydict:PtileLink .
+:linkc1_0c0s0a0l53 a craydict:PtileLink .
+:linkc1_0c0s0a0l54 a craydict:PtileLink .
+:linkc1_0c0s0a0l55 a craydict:PtileLink .
+:linkc1_0c0s0a0l56 a craydict:PtileLink .
+:linkc1_0c0s0a0l57 a craydict:PtileLink .
+:linkc1_0c0s10a0l07 a craydict:GreenLink .
+:linkc1_0c0s10a0l16 a craydict:GreenLink .
+:linkc1_0c0s10a0l17 a craydict:GreenLink .
+:linkc1_0c0s10a0l24 a craydict:GreenLink .
+:linkc1_0c0s10a0l25 a craydict:GreenLink .
+:linkc1_0c0s10a0l30 a craydict:BlackLink .
+:linkc1_0c0s10a0l40 a craydict:BlackLink .
+:linkc1_0c0s10a0l41 a craydict:BlackLink .
+:linkc1_0c0s10a0l50 a craydict:PtileLink .
+:linkc1_0c0s10a0l51 a craydict:PtileLink .
+:linkc1_0c0s10a0l52 a craydict:PtileLink .
+:linkc1_0c0s10a0l53 a craydict:PtileLink .
+:linkc1_0c0s10a0l54 a craydict:PtileLink .
+:linkc1_0c0s10a0l55 a craydict:PtileLink .
+:linkc1_0c0s10a0l56 a craydict:PtileLink .
+:linkc1_0c0s10a0l57 a craydict:PtileLink .
+:linkc1_0c0s11a0l07 a craydict:GreenLink .
+:linkc1_0c0s11a0l17 a craydict:GreenLink .
+:linkc1_0c0s11a0l24 a craydict:GreenLink .
+:linkc1_0c0s11a0l26 a craydict:GreenLink .
+:linkc1_0c0s11a0l30 a craydict:BlackLink .
+:linkc1_0c0s11a0l40 a craydict:BlackLink .
+:linkc1_0c0s11a0l41 a craydict:BlackLink .
+:linkc1_0c0s11a0l50 a craydict:PtileLink .
+:linkc1_0c0s11a0l51 a craydict:PtileLink .
+:linkc1_0c0s11a0l52 a craydict:PtileLink .
+:linkc1_0c0s11a0l53 a craydict:PtileLink .
+:linkc1_0c0s11a0l54 a craydict:PtileLink .
+:linkc1_0c0s11a0l55 a craydict:PtileLink .
+:linkc1_0c0s11a0l56 a craydict:PtileLink .
+:linkc1_0c0s11a0l57 a craydict:PtileLink .
+:linkc1_0c0s12a0l17 a craydict:GreenLink .
+:linkc1_0c0s12a0l24 a craydict:GreenLink .
+:linkc1_0c0s12a0l26 a craydict:GreenLink .
+:linkc1_0c0s12a0l30 a craydict:BlackLink .
+:linkc1_0c0s12a0l40 a craydict:BlackLink .
+:linkc1_0c0s12a0l41 a craydict:BlackLink .
+:linkc1_0c0s12a0l50 a craydict:PtileLink .
+:linkc1_0c0s12a0l51 a craydict:PtileLink .
+:linkc1_0c0s12a0l52 a craydict:PtileLink .
+:linkc1_0c0s12a0l53 a craydict:PtileLink .
+:linkc1_0c0s12a0l54 a craydict:PtileLink .
+:linkc1_0c0s12a0l55 a craydict:PtileLink .
+:linkc1_0c0s12a0l56 a craydict:PtileLink .
+:linkc1_0c0s12a0l57 a craydict:PtileLink .
+:linkc1_0c0s13a0l24 a craydict:GreenLink .
+:linkc1_0c0s13a0l25 a craydict:GreenLink .
+:linkc1_0c0s13a0l30 a craydict:BlackLink .
+:linkc1_0c0s13a0l40 a craydict:BlackLink .
+:linkc1_0c0s13a0l41 a craydict:BlackLink .
+:linkc1_0c0s13a0l50 a craydict:PtileLink .
+:linkc1_0c0s13a0l51 a craydict:PtileLink .
+:linkc1_0c0s13a0l52 a craydict:PtileLink .
+:linkc1_0c0s13a0l53 a craydict:PtileLink .
+:linkc1_0c0s13a0l54 a craydict:PtileLink .
+:linkc1_0c0s13a0l55 a craydict:PtileLink .
+:linkc1_0c0s13a0l56 a craydict:PtileLink .
+:linkc1_0c0s13a0l57 a craydict:PtileLink .
+:linkc1_0c0s14a0l24 a craydict:GreenLink .
+:linkc1_0c0s14a0l50 a craydict:PtileLink .
+:linkc1_0c0s14a0l51 a craydict:PtileLink .
+:linkc1_0c0s14a0l52 a craydict:PtileLink .
+:linkc1_0c0s14a0l53 a craydict:PtileLink .
+:linkc1_0c0s14a0l54 a craydict:PtileLink .
+:linkc1_0c0s14a0l55 a craydict:PtileLink .
+:linkc1_0c0s14a0l56 a craydict:PtileLink .
+:linkc1_0c0s14a0l57 a craydict:PtileLink .
+:linkc1_0c0s15a0l50 a craydict:PtileLink .
+:linkc1_0c0s15a0l51 a craydict:PtileLink .
+:linkc1_0c0s15a0l52 a craydict:PtileLink .
+:linkc1_0c0s15a0l53 a craydict:PtileLink .
+:linkc1_0c0s15a0l54 a craydict:PtileLink .
+:linkc1_0c0s15a0l55 a craydict:PtileLink .
+:linkc1_0c0s15a0l56 a craydict:PtileLink .
+:linkc1_0c0s15a0l57 a craydict:PtileLink .
+:linkc1_0c0s1a0l00 a craydict:GreenLink .
+:linkc1_0c0s1a0l10 a craydict:GreenLink .
+:linkc1_0c0s1a0l11 a craydict:GreenLink .
+:linkc1_0c0s1a0l21 a craydict:GreenLink .
+:linkc1_0c0s1a0l22 a craydict:GreenLink .
+:linkc1_0c0s1a0l23 a craydict:GreenLink .
+:linkc1_0c0s1a0l30 a craydict:GreenLink .
+:linkc1_0c0s1a0l31 a craydict:GreenLink .
+:linkc1_0c0s1a0l32 a craydict:GreenLink .
+:linkc1_0c0s1a0l33 a craydict:GreenLink .
+:linkc1_0c0s1a0l37 a craydict:BlackLink .
+:linkc1_0c0s1a0l40 a craydict:GreenLink .
+:linkc1_0c0s1a0l41 a craydict:GreenLink .
+:linkc1_0c0s1a0l42 a craydict:GreenLink .
+:linkc1_0c0s1a0l43 a craydict:GreenLink .
+:linkc1_0c0s1a0l46 a craydict:BlackLink .
+:linkc1_0c0s1a0l47 a craydict:BlackLink .
+:linkc1_0c0s1a0l50 a craydict:PtileLink .
+:linkc1_0c0s1a0l51 a craydict:PtileLink .
+:linkc1_0c0s1a0l52 a craydict:PtileLink .
+:linkc1_0c0s1a0l53 a craydict:PtileLink .
+:linkc1_0c0s1a0l54 a craydict:PtileLink .
+:linkc1_0c0s1a0l55 a craydict:PtileLink .
+:linkc1_0c0s1a0l56 a craydict:PtileLink .
+:linkc1_0c0s1a0l57 a craydict:PtileLink .
+:linkc1_0c0s2a0l00 a craydict:GreenLink .
+:linkc1_0c0s2a0l10 a craydict:GreenLink .
+:linkc1_0c0s2a0l11 a craydict:GreenLink .
+:linkc1_0c0s2a0l22 a craydict:GreenLink .
+:linkc1_0c0s2a0l23 a craydict:GreenLink .
+:linkc1_0c0s2a0l30 a craydict:GreenLink .
+:linkc1_0c0s2a0l31 a craydict:GreenLink .
+:linkc1_0c0s2a0l32 a craydict:GreenLink .
+:linkc1_0c0s2a0l33 a craydict:GreenLink .
+:linkc1_0c0s2a0l37 a craydict:BlackLink .
+:linkc1_0c0s2a0l40 a craydict:GreenLink .
+:linkc1_0c0s2a0l41 a craydict:GreenLink .
+:linkc1_0c0s2a0l42 a craydict:GreenLink .
+:linkc1_0c0s2a0l43 a craydict:GreenLink .
+:linkc1_0c0s2a0l46 a craydict:BlackLink .
+:linkc1_0c0s2a0l47 a craydict:BlackLink .
+:linkc1_0c0s2a0l50 a craydict:PtileLink .
+:linkc1_0c0s2a0l51 a craydict:PtileLink .
+:linkc1_0c0s2a0l52 a craydict:PtileLink .
+:linkc1_0c0s2a0l53 a craydict:PtileLink .
+:linkc1_0c0s2a0l54 a craydict:PtileLink .
+:linkc1_0c0s2a0l55 a craydict:PtileLink .
+:linkc1_0c0s2a0l56 a craydict:PtileLink .
+:linkc1_0c0s2a0l57 a craydict:PtileLink .
+:linkc1_0c0s3a0l00 a craydict:GreenLink .
+:linkc1_0c0s3a0l10 a craydict:GreenLink .
+:linkc1_0c0s3a0l21 a craydict:GreenLink .
+:linkc1_0c0s3a0l23 a craydict:GreenLink .
+:linkc1_0c0s3a0l30 a craydict:GreenLink .
+:linkc1_0c0s3a0l31 a craydict:GreenLink .
+:linkc1_0c0s3a0l32 a craydict:GreenLink .
+:linkc1_0c0s3a0l33 a craydict:GreenLink .
+:linkc1_0c0s3a0l37 a craydict:BlackLink .
+:linkc1_0c0s3a0l40 a craydict:GreenLink .
+:linkc1_0c0s3a0l41 a craydict:GreenLink .
+:linkc1_0c0s3a0l42 a craydict:GreenLink .
+:linkc1_0c0s3a0l43 a craydict:GreenLink .
+:linkc1_0c0s3a0l46 a craydict:BlackLink .
+:linkc1_0c0s3a0l47 a craydict:BlackLink .
+:linkc1_0c0s3a0l50 a craydict:PtileLink .
+:linkc1_0c0s3a0l51 a craydict:PtileLink .
+:linkc1_0c0s3a0l52 a craydict:PtileLink .
+:linkc1_0c0s3a0l53 a craydict:PtileLink .
+:linkc1_0c0s3a0l54 a craydict:PtileLink .
+:linkc1_0c0s3a0l55 a craydict:PtileLink .
+:linkc1_0c0s3a0l56 a craydict:PtileLink .
+:linkc1_0c0s3a0l57 a craydict:PtileLink .
+:linkc1_0c0s4a0l10 a craydict:GreenLink .
+:linkc1_0c0s4a0l21 a craydict:GreenLink .
+:linkc1_0c0s4a0l23 a craydict:GreenLink .
+:linkc1_0c0s4a0l30 a craydict:GreenLink .
+:linkc1_0c0s4a0l31 a craydict:GreenLink .
+:linkc1_0c0s4a0l32 a craydict:GreenLink .
+:linkc1_0c0s4a0l33 a craydict:GreenLink .
+:linkc1_0c0s4a0l37 a craydict:BlackLink .
+:linkc1_0c0s4a0l40 a craydict:GreenLink .
+:linkc1_0c0s4a0l41 a craydict:GreenLink .
+:linkc1_0c0s4a0l42 a craydict:GreenLink .
+:linkc1_0c0s4a0l43 a craydict:GreenLink .
+:linkc1_0c0s4a0l46 a craydict:BlackLink .
+:linkc1_0c0s4a0l47 a craydict:BlackLink .
+:linkc1_0c0s4a0l50 a craydict:PtileLink .
+:linkc1_0c0s4a0l51 a craydict:PtileLink .
+:linkc1_0c0s4a0l52 a craydict:PtileLink .
+:linkc1_0c0s4a0l53 a craydict:PtileLink .
+:linkc1_0c0s4a0l54 a craydict:PtileLink .
+:linkc1_0c0s4a0l55 a craydict:PtileLink .
+:linkc1_0c0s4a0l56 a craydict:PtileLink .
+:linkc1_0c0s4a0l57 a craydict:PtileLink .
+:linkc1_0c0s5a0l22 a craydict:GreenLink .
+:linkc1_0c0s5a0l23 a craydict:GreenLink .
+:linkc1_0c0s5a0l30 a craydict:GreenLink .
+:linkc1_0c0s5a0l31 a craydict:GreenLink .
+:linkc1_0c0s5a0l32 a craydict:GreenLink .
+:linkc1_0c0s5a0l33 a craydict:GreenLink .
+:linkc1_0c0s5a0l37 a craydict:BlackLink .
+:linkc1_0c0s5a0l40 a craydict:GreenLink .
+:linkc1_0c0s5a0l41 a craydict:GreenLink .
+:linkc1_0c0s5a0l42 a craydict:GreenLink .
+:linkc1_0c0s5a0l43 a craydict:GreenLink .
+:linkc1_0c0s5a0l46 a craydict:BlackLink .
+:linkc1_0c0s5a0l47 a craydict:BlackLink .
+:linkc1_0c0s5a0l50 a craydict:PtileLink .
+:linkc1_0c0s5a0l51 a craydict:PtileLink .
+:linkc1_0c0s5a0l52 a craydict:PtileLink .
+:linkc1_0c0s5a0l53 a craydict:PtileLink .
+:linkc1_0c0s5a0l54 a craydict:PtileLink .
+:linkc1_0c0s5a0l55 a craydict:PtileLink .
+:linkc1_0c0s5a0l56 a craydict:PtileLink .
+:linkc1_0c0s5a0l57 a craydict:PtileLink .
+:linkc1_0c0s6a0l23 a craydict:GreenLink .
+:linkc1_0c0s6a0l30 a craydict:GreenLink .
+:linkc1_0c0s6a0l31 a craydict:GreenLink .
+:linkc1_0c0s6a0l32 a craydict:GreenLink .
+:linkc1_0c0s6a0l33 a craydict:GreenLink .
+:linkc1_0c0s6a0l37 a craydict:BlackLink .
+:linkc1_0c0s6a0l40 a craydict:GreenLink .
+:linkc1_0c0s6a0l41 a craydict:GreenLink .
+:linkc1_0c0s6a0l42 a craydict:GreenLink .
+:linkc1_0c0s6a0l43 a craydict:GreenLink .
+:linkc1_0c0s6a0l46 a craydict:BlackLink .
+:linkc1_0c0s6a0l47 a craydict:BlackLink .
+:linkc1_0c0s6a0l50 a craydict:PtileLink .
+:linkc1_0c0s6a0l51 a craydict:PtileLink .
+:linkc1_0c0s6a0l52 a craydict:PtileLink .
+:linkc1_0c0s6a0l53 a craydict:PtileLink .
+:linkc1_0c0s6a0l54 a craydict:PtileLink .
+:linkc1_0c0s6a0l55 a craydict:PtileLink .
+:linkc1_0c0s6a0l56 a craydict:PtileLink .
+:linkc1_0c0s6a0l57 a craydict:PtileLink .
+:linkc1_0c0s7a0l30 a craydict:GreenLink .
+:linkc1_0c0s7a0l31 a craydict:GreenLink .
+:linkc1_0c0s7a0l32 a craydict:GreenLink .
+:linkc1_0c0s7a0l33 a craydict:GreenLink .
+:linkc1_0c0s7a0l37 a craydict:BlackLink .
+:linkc1_0c0s7a0l40 a craydict:GreenLink .
+:linkc1_0c0s7a0l41 a craydict:GreenLink .
+:linkc1_0c0s7a0l42 a craydict:GreenLink .
+:linkc1_0c0s7a0l43 a craydict:GreenLink .
+:linkc1_0c0s7a0l46 a craydict:BlackLink .
+:linkc1_0c0s7a0l47 a craydict:BlackLink .
+:linkc1_0c0s7a0l50 a craydict:PtileLink .
+:linkc1_0c0s7a0l51 a craydict:PtileLink .
+:linkc1_0c0s7a0l52 a craydict:PtileLink .
+:linkc1_0c0s7a0l53 a craydict:PtileLink .
+:linkc1_0c0s7a0l54 a craydict:PtileLink .
+:linkc1_0c0s7a0l55 a craydict:PtileLink .
+:linkc1_0c0s7a0l56 a craydict:PtileLink .
+:linkc1_0c0s7a0l57 a craydict:PtileLink .
+:linkc1_0c0s8a0l07 a craydict:GreenLink .
+:linkc1_0c0s8a0l16 a craydict:GreenLink .
+:linkc1_0c0s8a0l17 a craydict:GreenLink .
+:linkc1_0c0s8a0l24 a craydict:GreenLink .
+:linkc1_0c0s8a0l25 a craydict:GreenLink .
+:linkc1_0c0s8a0l26 a craydict:GreenLink .
+:linkc1_0c0s8a0l27 a craydict:GreenLink .
+:linkc1_0c0s8a0l30 a craydict:BlackLink .
+:linkc1_0c0s8a0l40 a craydict:BlackLink .
+:linkc1_0c0s8a0l41 a craydict:BlackLink .
+:linkc1_0c0s8a0l50 a craydict:PtileLink .
+:linkc1_0c0s8a0l51 a craydict:PtileLink .
+:linkc1_0c0s8a0l52 a craydict:PtileLink .
+:linkc1_0c0s8a0l53 a craydict:PtileLink .
+:linkc1_0c0s8a0l54 a craydict:PtileLink .
+:linkc1_0c0s8a0l55 a craydict:PtileLink .
+:linkc1_0c0s8a0l56 a craydict:PtileLink .
+:linkc1_0c0s8a0l57 a craydict:PtileLink .
+:linkc1_0c0s9a0l07 a craydict:GreenLink .
+:linkc1_0c0s9a0l16 a craydict:GreenLink .
+:linkc1_0c0s9a0l17 a craydict:GreenLink .
+:linkc1_0c0s9a0l24 a craydict:GreenLink .
+:linkc1_0c0s9a0l25 a craydict:GreenLink .
+:linkc1_0c0s9a0l26 a craydict:GreenLink .
+:linkc1_0c0s9a0l30 a craydict:BlackLink .
+:linkc1_0c0s9a0l40 a craydict:BlackLink .
+:linkc1_0c0s9a0l41 a craydict:BlackLink .
+:linkc1_0c0s9a0l50 a craydict:PtileLink .
+:linkc1_0c0s9a0l51 a craydict:PtileLink .
+:linkc1_0c0s9a0l52 a craydict:PtileLink .
+:linkc1_0c0s9a0l53 a craydict:PtileLink .
+:linkc1_0c0s9a0l54 a craydict:PtileLink .
+:linkc1_0c0s9a0l55 a craydict:PtileLink .
+:linkc1_0c0s9a0l56 a craydict:PtileLink .
+:linkc1_0c0s9a0l57 a craydict:PtileLink .
+:linkc1_0c1s0a0l00 a craydict:GreenLink .
+:linkc1_0c1s0a0l10 a craydict:GreenLink .
+:linkc1_0c1s0a0l11 a craydict:GreenLink .
+:linkc1_0c1s0a0l20 a craydict:GreenLink .
+:linkc1_0c1s0a0l21 a craydict:GreenLink .
+:linkc1_0c1s0a0l22 a craydict:GreenLink .
+:linkc1_0c1s0a0l23 a craydict:GreenLink .
+:linkc1_0c1s0a0l30 a craydict:GreenLink .
+:linkc1_0c1s0a0l31 a craydict:GreenLink .
+:linkc1_0c1s0a0l32 a craydict:GreenLink .
+:linkc1_0c1s0a0l33 a craydict:GreenLink .
+:linkc1_0c1s0a0l40 a craydict:GreenLink .
+:linkc1_0c1s0a0l43 a craydict:GreenLink .
+:linkc1_0c1s0a0l50 a craydict:PtileLink .
+:linkc1_0c1s0a0l51 a craydict:PtileLink .
+:linkc1_0c1s0a0l52 a craydict:PtileLink .
+:linkc1_0c1s0a0l53 a craydict:PtileLink .
+:linkc1_0c1s0a0l54 a craydict:PtileLink .
+:linkc1_0c1s0a0l55 a craydict:PtileLink .
+:linkc1_0c1s0a0l56 a craydict:PtileLink .
+:linkc1_0c1s0a0l57 a craydict:PtileLink .
+:linkc1_0c1s10a0l16 a craydict:GreenLink .
+:linkc1_0c1s10a0l24 a craydict:GreenLink .
+:linkc1_0c1s10a0l25 a craydict:GreenLink .
+:linkc1_0c1s10a0l50 a craydict:PtileLink .
+:linkc1_0c1s10a0l51 a craydict:PtileLink .
+:linkc1_0c1s10a0l52 a craydict:PtileLink .
+:linkc1_0c1s10a0l53 a craydict:PtileLink .
+:linkc1_0c1s10a0l54 a craydict:PtileLink .
+:linkc1_0c1s10a0l55 a craydict:PtileLink .
+:linkc1_0c1s10a0l56 a craydict:PtileLink .
+:linkc1_0c1s10a0l57 a craydict:PtileLink .
+:linkc1_0c1s11a0l07 a craydict:GreenLink .
+:linkc1_0c1s11a0l24 a craydict:GreenLink .
+:linkc1_0c1s11a0l50 a craydict:PtileLink .
+:linkc1_0c1s11a0l51 a craydict:PtileLink .
+:linkc1_0c1s11a0l52 a craydict:PtileLink .
+:linkc1_0c1s11a0l53 a craydict:PtileLink .
+:linkc1_0c1s11a0l54 a craydict:PtileLink .
+:linkc1_0c1s11a0l55 a craydict:PtileLink .
+:linkc1_0c1s11a0l56 a craydict:PtileLink .
+:linkc1_0c1s11a0l57 a craydict:PtileLink .
+:linkc1_0c1s12a0l24 a craydict:GreenLink .
+:linkc1_0c1s12a0l50 a craydict:PtileLink .
+:linkc1_0c1s12a0l51 a craydict:PtileLink .
+:linkc1_0c1s12a0l52 a craydict:PtileLink .
+:linkc1_0c1s12a0l53 a craydict:PtileLink .
+:linkc1_0c1s12a0l54 a craydict:PtileLink .
+:linkc1_0c1s12a0l55 a craydict:PtileLink .
+:linkc1_0c1s12a0l56 a craydict:PtileLink .
+:linkc1_0c1s12a0l57 a craydict:PtileLink .
+:linkc1_0c1s13a0l50 a craydict:PtileLink .
+:linkc1_0c1s13a0l51 a craydict:PtileLink .
+:linkc1_0c1s13a0l52 a craydict:PtileLink .
+:linkc1_0c1s13a0l53 a craydict:PtileLink .
+:linkc1_0c1s13a0l54 a craydict:PtileLink .
+:linkc1_0c1s13a0l55 a craydict:PtileLink .
+:linkc1_0c1s13a0l56 a craydict:PtileLink .
+:linkc1_0c1s13a0l57 a craydict:PtileLink .
+:linkc1_0c1s1a0l00 a craydict:GreenLink .
+:linkc1_0c1s1a0l10 a craydict:GreenLink .
+:linkc1_0c1s1a0l11 a craydict:GreenLink .
+:linkc1_0c1s1a0l21 a craydict:GreenLink .
+:linkc1_0c1s1a0l22 a craydict:GreenLink .
+:linkc1_0c1s1a0l23 a craydict:GreenLink .
+:linkc1_0c1s1a0l30 a craydict:GreenLink .
+:linkc1_0c1s1a0l31 a craydict:GreenLink .
+:linkc1_0c1s1a0l32 a craydict:GreenLink .
+:linkc1_0c1s1a0l41 a craydict:GreenLink .
+:linkc1_0c1s1a0l42 a craydict:GreenLink .
+:linkc1_0c1s1a0l43 a craydict:GreenLink .
+:linkc1_0c1s1a0l50 a craydict:PtileLink .
+:linkc1_0c1s1a0l51 a craydict:PtileLink .
+:linkc1_0c1s1a0l52 a craydict:PtileLink .
+:linkc1_0c1s1a0l53 a craydict:PtileLink .
+:linkc1_0c1s1a0l54 a craydict:PtileLink .
+:linkc1_0c1s1a0l55 a craydict:PtileLink .
+:linkc1_0c1s1a0l56 a craydict:PtileLink .
+:linkc1_0c1s1a0l57 a craydict:PtileLink .
+:linkc1_0c1s2a0l00 a craydict:GreenLink .
+:linkc1_0c1s2a0l10 a craydict:GreenLink .
+:linkc1_0c1s2a0l11 a craydict:GreenLink .
+:linkc1_0c1s2a0l22 a craydict:GreenLink .
+:linkc1_0c1s2a0l23 a craydict:GreenLink .
+:linkc1_0c1s2a0l30 a craydict:GreenLink .
+:linkc1_0c1s2a0l31 a craydict:GreenLink .
+:linkc1_0c1s2a0l32 a craydict:GreenLink .
+:linkc1_0c1s2a0l33 a craydict:GreenLink .
+:linkc1_0c1s2a0l40 a craydict:GreenLink .
+:linkc1_0c1s2a0l41 a craydict:GreenLink .
+:linkc1_0c1s2a0l50 a craydict:PtileLink .
+:linkc1_0c1s2a0l51 a craydict:PtileLink .
+:linkc1_0c1s2a0l52 a craydict:PtileLink .
+:linkc1_0c1s2a0l53 a craydict:PtileLink .
+:linkc1_0c1s2a0l54 a craydict:PtileLink .
+:linkc1_0c1s2a0l55 a craydict:PtileLink .
+:linkc1_0c1s2a0l56 a craydict:PtileLink .
+:linkc1_0c1s2a0l57 a craydict:PtileLink .
+:linkc1_0c1s3a0l00 a craydict:GreenLink .
+:linkc1_0c1s3a0l10 a craydict:GreenLink .
+:linkc1_0c1s3a0l21 a craydict:GreenLink .
+:linkc1_0c1s3a0l23 a craydict:GreenLink .
+:linkc1_0c1s3a0l31 a craydict:GreenLink .
+:linkc1_0c1s3a0l33 a craydict:GreenLink .
+:linkc1_0c1s3a0l40 a craydict:GreenLink .
+:linkc1_0c1s3a0l41 a craydict:GreenLink .
+:linkc1_0c1s3a0l42 a craydict:GreenLink .
+:linkc1_0c1s3a0l43 a craydict:GreenLink .
+:linkc1_0c1s3a0l50 a craydict:PtileLink .
+:linkc1_0c1s3a0l51 a craydict:PtileLink .
+:linkc1_0c1s3a0l52 a craydict:PtileLink .
+:linkc1_0c1s3a0l53 a craydict:PtileLink .
+:linkc1_0c1s3a0l54 a craydict:PtileLink .
+:linkc1_0c1s3a0l55 a craydict:PtileLink .
+:linkc1_0c1s3a0l56 a craydict:PtileLink .
+:linkc1_0c1s3a0l57 a craydict:PtileLink .
+:linkc1_0c1s4a0l10 a craydict:GreenLink .
+:linkc1_0c1s4a0l21 a craydict:GreenLink .
+:linkc1_0c1s4a0l23 a craydict:GreenLink .
+:linkc1_0c1s4a0l30 a craydict:GreenLink .
+:linkc1_0c1s4a0l32 a craydict:GreenLink .
+:linkc1_0c1s4a0l33 a craydict:GreenLink .
+:linkc1_0c1s4a0l40 a craydict:GreenLink .
+:linkc1_0c1s4a0l41 a craydict:GreenLink .
+:linkc1_0c1s4a0l43 a craydict:GreenLink .
+:linkc1_0c1s4a0l50 a craydict:PtileLink .
+:linkc1_0c1s4a0l51 a craydict:PtileLink .
+:linkc1_0c1s4a0l52 a craydict:PtileLink .
+:linkc1_0c1s4a0l53 a craydict:PtileLink .
+:linkc1_0c1s4a0l54 a craydict:PtileLink .
+:linkc1_0c1s4a0l55 a craydict:PtileLink .
+:linkc1_0c1s4a0l56 a craydict:PtileLink .
+:linkc1_0c1s4a0l57 a craydict:PtileLink .
+:linkc1_0c1s5a0l22 a craydict:GreenLink .
+:linkc1_0c1s5a0l23 a craydict:GreenLink .
+:linkc1_0c1s5a0l32 a craydict:GreenLink .
+:linkc1_0c1s5a0l33 a craydict:GreenLink .
+:linkc1_0c1s5a0l40 a craydict:GreenLink .
+:linkc1_0c1s5a0l41 a craydict:GreenLink .
+:linkc1_0c1s5a0l42 a craydict:GreenLink .
+:linkc1_0c1s5a0l43 a craydict:GreenLink .
+:linkc1_0c1s5a0l50 a craydict:PtileLink .
+:linkc1_0c1s5a0l51 a craydict:PtileLink .
+:linkc1_0c1s5a0l52 a craydict:PtileLink .
+:linkc1_0c1s5a0l53 a craydict:PtileLink .
+:linkc1_0c1s5a0l54 a craydict:PtileLink .
+:linkc1_0c1s5a0l55 a craydict:PtileLink .
+:linkc1_0c1s5a0l56 a craydict:PtileLink .
+:linkc1_0c1s5a0l57 a craydict:PtileLink .
+:linkc1_0c1s6a0l23 a craydict:GreenLink .
+:linkc1_0c1s6a0l30 a craydict:GreenLink .
+:linkc1_0c1s6a0l31 a craydict:GreenLink .
+:linkc1_0c1s6a0l33 a craydict:GreenLink .
+:linkc1_0c1s6a0l40 a craydict:GreenLink .
+:linkc1_0c1s6a0l41 a craydict:GreenLink .
+:linkc1_0c1s6a0l43 a craydict:GreenLink .
+:linkc1_0c1s6a0l50 a craydict:PtileLink .
+:linkc1_0c1s6a0l51 a craydict:PtileLink .
+:linkc1_0c1s6a0l52 a craydict:PtileLink .
+:linkc1_0c1s6a0l53 a craydict:PtileLink .
+:linkc1_0c1s6a0l54 a craydict:PtileLink .
+:linkc1_0c1s6a0l55 a craydict:PtileLink .
+:linkc1_0c1s6a0l56 a craydict:PtileLink .
+:linkc1_0c1s6a0l57 a craydict:PtileLink .
+:linkc1_0c1s7a0l30 a craydict:GreenLink .
+:linkc1_0c1s7a0l32 a craydict:GreenLink .
+:linkc1_0c1s7a0l33 a craydict:GreenLink .
+:linkc1_0c1s7a0l40 a craydict:GreenLink .
+:linkc1_0c1s7a0l41 a craydict:GreenLink .
+:linkc1_0c1s7a0l42 a craydict:GreenLink .
+:linkc1_0c1s7a0l50 a craydict:PtileLink .
+:linkc1_0c1s7a0l51 a craydict:PtileLink .
+:linkc1_0c1s7a0l52 a craydict:PtileLink .
+:linkc1_0c1s7a0l53 a craydict:PtileLink .
+:linkc1_0c1s7a0l54 a craydict:PtileLink .
+:linkc1_0c1s7a0l55 a craydict:PtileLink .
+:linkc1_0c1s7a0l56 a craydict:PtileLink .
+:linkc1_0c1s7a0l57 a craydict:PtileLink .
+:linkc1_0c1s8a0l17 a craydict:GreenLink .
+:linkc1_0c1s8a0l24 a craydict:GreenLink .
+:linkc1_0c1s8a0l25 a craydict:GreenLink .
+:linkc1_0c1s8a0l26 a craydict:GreenLink .
+:linkc1_0c1s8a0l27 a craydict:GreenLink .
+:linkc1_0c1s8a0l50 a craydict:PtileLink .
+:linkc1_0c1s8a0l51 a craydict:PtileLink .
+:linkc1_0c1s8a0l52 a craydict:PtileLink .
+:linkc1_0c1s8a0l53 a craydict:PtileLink .
+:linkc1_0c1s8a0l54 a craydict:PtileLink .
+:linkc1_0c1s8a0l55 a craydict:PtileLink .
+:linkc1_0c1s8a0l56 a craydict:PtileLink .
+:linkc1_0c1s8a0l57 a craydict:PtileLink .
+:linkc1_0c1s9a0l07 a craydict:GreenLink .
+:linkc1_0c1s9a0l16 a craydict:GreenLink .
+:linkc1_0c1s9a0l24 a craydict:GreenLink .
+:linkc1_0c1s9a0l26 a craydict:GreenLink .
+:linkc1_0c1s9a0l50 a craydict:PtileLink .
+:linkc1_0c1s9a0l51 a craydict:PtileLink .
+:linkc1_0c1s9a0l52 a craydict:PtileLink .
+:linkc1_0c1s9a0l53 a craydict:PtileLink .
+:linkc1_0c1s9a0l54 a craydict:PtileLink .
+:linkc1_0c1s9a0l55 a craydict:PtileLink .
+:linkc1_0c1s9a0l56 a craydict:PtileLink .
+:linkc1_0c1s9a0l57 a craydict:PtileLink .
+
+:c0_0c0s0a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l00;	.
+:c0_0c0s0a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l10;	.
+:c0_0c0s0a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l11;	.
+:c0_0c0s0a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l20;	.
+:c0_0c0s0a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l21;	.
+:c0_0c0s0a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l22;	.
+:c0_0c0s0a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l23;	.
+:c0_0c0s0a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l24;	.
+:c0_0c0s0a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l25;	.
+:c0_0c0s0a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l26;	.
+:c0_0c0s0a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l27;	.
+:c0_0c0s0a0l30 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l31;	.
+:c0_0c0s0a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l32;	.
+:c0_0c0s0a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l33;	.
+:c0_0c0s0a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l34;	.
+:c0_0c0s0a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l35;	.
+:c0_0c0s0a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l36;	.
+:c0_0c0s0a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l37;	.
+:c0_0c0s0a0l40 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l41 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s0a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l43;	.
+:c0_0c0s0a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l44;	.
+:c0_0c0s0a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l45;	.
+:c0_0c0s0a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l46;	.
+:c0_0c0s0a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l47;	.
+:c0_0c0s0a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l50;	.
+:c0_0c0s0a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l51;	.
+:c0_0c0s0a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l52;	.
+:c0_0c0s0a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l53;	.
+:c0_0c0s0a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l54;	.
+:c0_0c0s0a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l55;	.
+:c0_0c0s0a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l56;	.
+:c0_0c0s0a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s0a0l57;	.
+:c0_0c0s0a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s0n0;
+	logset:endPointOf :linkc0_0c0s0a0l50;
+	logset:endPointOf :linkc0_0c0s0a0l51;	.
+:c0_0c0s0a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s0n1;
+	logset:endPointOf :linkc0_0c0s0a0l52;
+	logset:endPointOf :linkc0_0c0s0a0l53;	.
+:c0_0c0s0a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s0n2;
+	logset:endPointOf :linkc0_0c0s0a0l54;
+	logset:endPointOf :linkc0_0c0s0a0l55;	.
+:c0_0c0s0a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s0n3;
+	logset:endPointOf :linkc0_0c0s0a0l56;
+	logset:endPointOf :linkc0_0c0s0a0l57;	.
+:c0_0c0s0n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s0n0;	.
+:c0_0c0s0n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s0n1;	.
+:c0_0c0s0n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s0n2;	.
+:c0_0c0s0n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s0n3;	.
+:c0_0c0s10a0l00 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l10 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l11 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l20;	.
+:c0_0c0s10a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l21;	.
+:c0_0c0s10a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l22;	.
+:c0_0c0s10a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l23;	.
+:c0_0c0s10a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l24;	.
+:c0_0c0s10a0l25 a craydict:NetworkTile ;	.
+:c0_0c0s10a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l26;	.
+:c0_0c0s10a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l24;	.
+:c0_0c0s10a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l30;	.
+:c0_0c0s10a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l31;	.
+:c0_0c0s10a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l32;	.
+:c0_0c0s10a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l33;	.
+:c0_0c0s10a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l32;	.
+:c0_0c0s10a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l30;	.
+:c0_0c0s10a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l31;	.
+:c0_0c0s10a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l40;	.
+:c0_0c0s10a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l40;	.
+:c0_0c0s10a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l41;	.
+:c0_0c0s10a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l42;	.
+:c0_0c0s10a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l43;	.
+:c0_0c0s10a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l33;	.
+:c0_0c0s10a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l43;	.
+:c0_0c0s10a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l41;	.
+:c0_0c0s10a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l41;	.
+:c0_0c0s10a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l50;	.
+:c0_0c0s10a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l51;	.
+:c0_0c0s10a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l52;	.
+:c0_0c0s10a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l53;	.
+:c0_0c0s10a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l54;	.
+:c0_0c0s10a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l55;	.
+:c0_0c0s10a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l56;	.
+:c0_0c0s10a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s10a0l57;	.
+:c0_0c0s10a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s10n0;
+	logset:endPointOf :linkc0_0c0s10a0l50;
+	logset:endPointOf :linkc0_0c0s10a0l51;	.
+:c0_0c0s10a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s10n1;
+	logset:endPointOf :linkc0_0c0s10a0l52;
+	logset:endPointOf :linkc0_0c0s10a0l53;	.
+:c0_0c0s10a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s10n2;
+	logset:endPointOf :linkc0_0c0s10a0l54;
+	logset:endPointOf :linkc0_0c0s10a0l55;	.
+:c0_0c0s10a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s10n3;
+	logset:endPointOf :linkc0_0c0s10a0l56;
+	logset:endPointOf :linkc0_0c0s10a0l57;	.
+:c0_0c0s10n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s10n0;	.
+:c0_0c0s10n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s10n1;	.
+:c0_0c0s10n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s10n2;	.
+:c0_0c0s10n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s10n3;	.
+:c0_0c0s11a0l00 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l10 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l11 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l07;	.
+:c0_0c0s11a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l20;	.
+:c0_0c0s11a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l21;	.
+:c0_0c0s11a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l22;	.
+:c0_0c0s11a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l23;	.
+:c0_0c0s11a0l24 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l17;	.
+:c0_0c0s11a0l26 a craydict:NetworkTile ;	.
+:c0_0c0s11a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l24;	.
+:c0_0c0s11a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l30;	.
+:c0_0c0s11a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l31;	.
+:c0_0c0s11a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l32;	.
+:c0_0c0s11a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l33;	.
+:c0_0c0s11a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l43;	.
+:c0_0c0s11a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l41;	.
+:c0_0c0s11a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l43;	.
+:c0_0c0s11a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l31;	.
+:c0_0c0s11a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l40;	.
+:c0_0c0s11a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l41;	.
+:c0_0c0s11a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l42;	.
+:c0_0c0s11a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l43;	.
+:c0_0c0s11a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l33;	.
+:c0_0c0s11a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l30;	.
+:c0_0c0s11a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l42;	.
+:c0_0c0s11a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l42;	.
+:c0_0c0s11a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l50;	.
+:c0_0c0s11a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l51;	.
+:c0_0c0s11a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l52;	.
+:c0_0c0s11a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l53;	.
+:c0_0c0s11a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l54;	.
+:c0_0c0s11a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l55;	.
+:c0_0c0s11a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l56;	.
+:c0_0c0s11a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s11a0l57;	.
+:c0_0c0s11a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s11n0;
+	logset:endPointOf :linkc0_0c0s11a0l50;
+	logset:endPointOf :linkc0_0c0s11a0l51;	.
+:c0_0c0s11a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s11n1;
+	logset:endPointOf :linkc0_0c0s11a0l52;
+	logset:endPointOf :linkc0_0c0s11a0l53;	.
+:c0_0c0s11a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s11n2;
+	logset:endPointOf :linkc0_0c0s11a0l54;
+	logset:endPointOf :linkc0_0c0s11a0l55;	.
+:c0_0c0s11a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s11n3;
+	logset:endPointOf :linkc0_0c0s11a0l56;
+	logset:endPointOf :linkc0_0c0s11a0l57;	.
+:c0_0c0s11n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s11n0;	.
+:c0_0c0s11n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s11n1;	.
+:c0_0c0s11n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s11n2;	.
+:c0_0c0s11n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s11n3;	.
+:c0_0c0s1a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l00;	.
+:c0_0c0s1a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l10;	.
+:c0_0c0s1a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l11;	.
+:c0_0c0s1a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l23;	.
+:c0_0c0s1a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l21;	.
+:c0_0c0s1a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l22;	.
+:c0_0c0s1a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l23;	.
+:c0_0c0s1a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l24;	.
+:c0_0c0s1a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l25;	.
+:c0_0c0s1a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l26;	.
+:c0_0c0s1a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l27;	.
+:c0_0c0s1a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l30;	.
+:c0_0c0s1a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l31;	.
+:c0_0c0s1a0l32 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l33 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l34;	.
+:c0_0c0s1a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l35;	.
+:c0_0c0s1a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l36;	.
+:c0_0c0s1a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l37;	.
+:c0_0c0s1a0l40 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l41;	.
+:c0_0c0s1a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s1a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l43;	.
+:c0_0c0s1a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l44;	.
+:c0_0c0s1a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l45;	.
+:c0_0c0s1a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l46;	.
+:c0_0c0s1a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l47;	.
+:c0_0c0s1a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l50;	.
+:c0_0c0s1a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l51;	.
+:c0_0c0s1a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l52;	.
+:c0_0c0s1a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l53;	.
+:c0_0c0s1a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l54;	.
+:c0_0c0s1a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l55;	.
+:c0_0c0s1a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l56;	.
+:c0_0c0s1a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s1a0l57;	.
+:c0_0c0s1a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s1n0;
+	logset:endPointOf :linkc0_0c0s1a0l50;
+	logset:endPointOf :linkc0_0c0s1a0l51;	.
+:c0_0c0s1a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s1n1;
+	logset:endPointOf :linkc0_0c0s1a0l52;
+	logset:endPointOf :linkc0_0c0s1a0l53;	.
+:c0_0c0s1a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s1n2;
+	logset:endPointOf :linkc0_0c0s1a0l54;
+	logset:endPointOf :linkc0_0c0s1a0l55;	.
+:c0_0c0s1a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s1n3;
+	logset:endPointOf :linkc0_0c0s1a0l56;
+	logset:endPointOf :linkc0_0c0s1a0l57;	.
+:c0_0c0s1n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s1n0;	.
+:c0_0c0s1n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s1n1;	.
+:c0_0c0s1n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s1n2;	.
+:c0_0c0s1n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s1n3;	.
+:c0_0c0s2a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l00;	.
+:c0_0c0s2a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l10;	.
+:c0_0c0s2a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l11;	.
+:c0_0c0s2a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l23;	.
+:c0_0c0s2a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l10;	.
+:c0_0c0s2a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l22;	.
+:c0_0c0s2a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l23;	.
+:c0_0c0s2a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l24;	.
+:c0_0c0s2a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l25;	.
+:c0_0c0s2a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l26;	.
+:c0_0c0s2a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l27;	.
+:c0_0c0s2a0l30 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l31 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l32;	.
+:c0_0c0s2a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l33;	.
+:c0_0c0s2a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l34;	.
+:c0_0c0s2a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l35;	.
+:c0_0c0s2a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l36;	.
+:c0_0c0s2a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l37;	.
+:c0_0c0s2a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l40;	.
+:c0_0c0s2a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l41;	.
+:c0_0c0s2a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l43 a craydict:NetworkTile ;	.
+:c0_0c0s2a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l44;	.
+:c0_0c0s2a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l45;	.
+:c0_0c0s2a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l46;	.
+:c0_0c0s2a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l47;	.
+:c0_0c0s2a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l50;	.
+:c0_0c0s2a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l51;	.
+:c0_0c0s2a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l52;	.
+:c0_0c0s2a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l53;	.
+:c0_0c0s2a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l54;	.
+:c0_0c0s2a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l55;	.
+:c0_0c0s2a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l56;	.
+:c0_0c0s2a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s2a0l57;	.
+:c0_0c0s2a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s2n0;
+	logset:endPointOf :linkc0_0c0s2a0l50;
+	logset:endPointOf :linkc0_0c0s2a0l51;	.
+:c0_0c0s2a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s2n1;
+	logset:endPointOf :linkc0_0c0s2a0l52;
+	logset:endPointOf :linkc0_0c0s2a0l53;	.
+:c0_0c0s2a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s2n2;
+	logset:endPointOf :linkc0_0c0s2a0l54;
+	logset:endPointOf :linkc0_0c0s2a0l55;	.
+:c0_0c0s2a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s2n3;
+	logset:endPointOf :linkc0_0c0s2a0l56;
+	logset:endPointOf :linkc0_0c0s2a0l57;	.
+:c0_0c0s2n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s2n0;	.
+:c0_0c0s2n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s2n1;	.
+:c0_0c0s2n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s2n2;	.
+:c0_0c0s2n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s2n3;	.
+:c0_0c0s3a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l00;	.
+:c0_0c0s3a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l10;	.
+:c0_0c0s3a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l00;	.
+:c0_0c0s3a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l23;	.
+:c0_0c0s3a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l21;	.
+:c0_0c0s3a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l21;	.
+:c0_0c0s3a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l23;	.
+:c0_0c0s3a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l24;	.
+:c0_0c0s3a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l25;	.
+:c0_0c0s3a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l26;	.
+:c0_0c0s3a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l27;	.
+:c0_0c0s3a0l30 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l31 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l32 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l33;	.
+:c0_0c0s3a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l34;	.
+:c0_0c0s3a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l35;	.
+:c0_0c0s3a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l36;	.
+:c0_0c0s3a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l37;	.
+:c0_0c0s3a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l40;	.
+:c0_0c0s3a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l41;	.
+:c0_0c0s3a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s3a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l43;	.
+:c0_0c0s3a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l44;	.
+:c0_0c0s3a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l45;	.
+:c0_0c0s3a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l46;	.
+:c0_0c0s3a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l47;	.
+:c0_0c0s3a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l50;	.
+:c0_0c0s3a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l51;	.
+:c0_0c0s3a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l52;	.
+:c0_0c0s3a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l53;	.
+:c0_0c0s3a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l54;	.
+:c0_0c0s3a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l55;	.
+:c0_0c0s3a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l56;	.
+:c0_0c0s3a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s3a0l57;	.
+:c0_0c0s3a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s3n0;
+	logset:endPointOf :linkc0_0c0s3a0l50;
+	logset:endPointOf :linkc0_0c0s3a0l51;	.
+:c0_0c0s3a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s3n1;
+	logset:endPointOf :linkc0_0c0s3a0l52;
+	logset:endPointOf :linkc0_0c0s3a0l53;	.
+:c0_0c0s3a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s3n2;
+	logset:endPointOf :linkc0_0c0s3a0l54;
+	logset:endPointOf :linkc0_0c0s3a0l55;	.
+:c0_0c0s3a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s3n3;
+	logset:endPointOf :linkc0_0c0s3a0l56;
+	logset:endPointOf :linkc0_0c0s3a0l57;	.
+:c0_0c0s3n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s3n0;	.
+:c0_0c0s3n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s3n1;	.
+:c0_0c0s3n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s3n2;	.
+:c0_0c0s3n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s3n3;	.
+:c0_0c0s4a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l21;	.
+:c0_0c0s4a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l10;	.
+:c0_0c0s4a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l11;	.
+:c0_0c0s4a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l23;	.
+:c0_0c0s4a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l21;	.
+:c0_0c0s4a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l20;	.
+:c0_0c0s4a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l23;	.
+:c0_0c0s4a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l24;	.
+:c0_0c0s4a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l25;	.
+:c0_0c0s4a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l26;	.
+:c0_0c0s4a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l27;	.
+:c0_0c0s4a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l30;	.
+:c0_0c0s4a0l31 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l32 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l33 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l34;	.
+:c0_0c0s4a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l35;	.
+:c0_0c0s4a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l36;	.
+:c0_0c0s4a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l37;	.
+:c0_0c0s4a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l40;	.
+:c0_0c0s4a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l41;	.
+:c0_0c0s4a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s4a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l43;	.
+:c0_0c0s4a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l44;	.
+:c0_0c0s4a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l45;	.
+:c0_0c0s4a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l46;	.
+:c0_0c0s4a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l47;	.
+:c0_0c0s4a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l50;	.
+:c0_0c0s4a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l51;	.
+:c0_0c0s4a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l52;	.
+:c0_0c0s4a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l53;	.
+:c0_0c0s4a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l54;	.
+:c0_0c0s4a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l55;	.
+:c0_0c0s4a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l56;	.
+:c0_0c0s4a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s4a0l57;	.
+:c0_0c0s4a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s4n0;
+	logset:endPointOf :linkc0_0c0s4a0l50;
+	logset:endPointOf :linkc0_0c0s4a0l51;	.
+:c0_0c0s4a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s4n1;
+	logset:endPointOf :linkc0_0c0s4a0l52;
+	logset:endPointOf :linkc0_0c0s4a0l53;	.
+:c0_0c0s4a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s4n2;
+	logset:endPointOf :linkc0_0c0s4a0l54;
+	logset:endPointOf :linkc0_0c0s4a0l55;	.
+:c0_0c0s4a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s4n3;
+	logset:endPointOf :linkc0_0c0s4a0l56;
+	logset:endPointOf :linkc0_0c0s4a0l57;	.
+:c0_0c0s4n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s4n0;	.
+:c0_0c0s4n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s4n1;	.
+:c0_0c0s4n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s4n2;	.
+:c0_0c0s4n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s4n3;	.
+:c0_0c0s5a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l11;	.
+:c0_0c0s5a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l22;	.
+:c0_0c0s5a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l00;	.
+:c0_0c0s5a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l23;	.
+:c0_0c0s5a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l22;	.
+:c0_0c0s5a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l22;	.
+:c0_0c0s5a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l23;	.
+:c0_0c0s5a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l24;	.
+:c0_0c0s5a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l25;	.
+:c0_0c0s5a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l26;	.
+:c0_0c0s5a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l27;	.
+:c0_0c0s5a0l30 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l31 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l32;	.
+:c0_0c0s5a0l33 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l34;	.
+:c0_0c0s5a0l35 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l36 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l37;	.
+:c0_0c0s5a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l40;	.
+:c0_0c0s5a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l41;	.
+:c0_0c0s5a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l42;	.
+:c0_0c0s5a0l43 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l44;	.
+:c0_0c0s5a0l45 a craydict:NetworkTile ;	.
+:c0_0c0s5a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l46;	.
+:c0_0c0s5a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l47;	.
+:c0_0c0s5a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l50;	.
+:c0_0c0s5a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l51;	.
+:c0_0c0s5a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l52;	.
+:c0_0c0s5a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l53;	.
+:c0_0c0s5a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l54;	.
+:c0_0c0s5a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l55;	.
+:c0_0c0s5a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l56;	.
+:c0_0c0s5a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s5a0l57;	.
+:c0_0c0s5a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s5n0;
+	logset:endPointOf :linkc0_0c0s5a0l50;
+	logset:endPointOf :linkc0_0c0s5a0l51;	.
+:c0_0c0s5a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s5n1;
+	logset:endPointOf :linkc0_0c0s5a0l52;
+	logset:endPointOf :linkc0_0c0s5a0l53;	.
+:c0_0c0s5a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s5n2;
+	logset:endPointOf :linkc0_0c0s5a0l54;
+	logset:endPointOf :linkc0_0c0s5a0l55;	.
+:c0_0c0s5a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s5n3;
+	logset:endPointOf :linkc0_0c0s5a0l56;
+	logset:endPointOf :linkc0_0c0s5a0l57;	.
+:c0_0c0s5n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s5n0;	.
+:c0_0c0s5n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s5n1;	.
+:c0_0c0s5n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s5n2;	.
+:c0_0c0s5n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s5n3;	.
+:c0_0c0s6a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l10;	.
+:c0_0c0s6a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l00;	.
+:c0_0c0s6a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l00;	.
+:c0_0c0s6a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l23;	.
+:c0_0c0s6a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l10;	.
+:c0_0c0s6a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l10;	.
+:c0_0c0s6a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l23;	.
+:c0_0c0s6a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l24;	.
+:c0_0c0s6a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l25;	.
+:c0_0c0s6a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l26;	.
+:c0_0c0s6a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l27;	.
+:c0_0c0s6a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l30;	.
+:c0_0c0s6a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l31;	.
+:c0_0c0s6a0l32 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l33 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l34;	.
+:c0_0c0s6a0l35 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l36 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l37;	.
+:c0_0c0s6a0l40 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l41;	.
+:c0_0c0s6a0l42 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l43;	.
+:c0_0c0s6a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l44;	.
+:c0_0c0s6a0l45 a craydict:NetworkTile ;	.
+:c0_0c0s6a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l46;	.
+:c0_0c0s6a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l47;	.
+:c0_0c0s6a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l50;	.
+:c0_0c0s6a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l51;	.
+:c0_0c0s6a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l52;	.
+:c0_0c0s6a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l53;	.
+:c0_0c0s6a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l54;	.
+:c0_0c0s6a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l55;	.
+:c0_0c0s6a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l56;	.
+:c0_0c0s6a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s6a0l57;	.
+:c0_0c0s6a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s6n0;
+	logset:endPointOf :linkc0_0c0s6a0l50;
+	logset:endPointOf :linkc0_0c0s6a0l51;	.
+:c0_0c0s6a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s6n1;
+	logset:endPointOf :linkc0_0c0s6a0l52;
+	logset:endPointOf :linkc0_0c0s6a0l53;	.
+:c0_0c0s6a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s6n2;
+	logset:endPointOf :linkc0_0c0s6a0l54;
+	logset:endPointOf :linkc0_0c0s6a0l55;	.
+:c0_0c0s6a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s6n3;
+	logset:endPointOf :linkc0_0c0s6a0l56;
+	logset:endPointOf :linkc0_0c0s6a0l57;	.
+:c0_0c0s6n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s6n0;	.
+:c0_0c0s6n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s6n1;	.
+:c0_0c0s6n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s6n2;	.
+:c0_0c0s6n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s6n3;	.
+:c0_0c0s7a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l11;	.
+:c0_0c0s7a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l21;	.
+:c0_0c0s7a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l22;	.
+:c0_0c0s7a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l23;	.
+:c0_0c0s7a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l10;	.
+:c0_0c0s7a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l21;	.
+:c0_0c0s7a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l22;	.
+:c0_0c0s7a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l24;	.
+:c0_0c0s7a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l25;	.
+:c0_0c0s7a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l26;	.
+:c0_0c0s7a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l27;	.
+:c0_0c0s7a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l30;	.
+:c0_0c0s7a0l31 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l32 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l33 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l34;	.
+:c0_0c0s7a0l35 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l36 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l37;	.
+:c0_0c0s7a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l40;	.
+:c0_0c0s7a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l41;	.
+:c0_0c0s7a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l42;	.
+:c0_0c0s7a0l43 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l44;	.
+:c0_0c0s7a0l45 a craydict:NetworkTile ;	.
+:c0_0c0s7a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l46;	.
+:c0_0c0s7a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l47;	.
+:c0_0c0s7a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l50;	.
+:c0_0c0s7a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l51;	.
+:c0_0c0s7a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l52;	.
+:c0_0c0s7a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l53;	.
+:c0_0c0s7a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l54;	.
+:c0_0c0s7a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l55;	.
+:c0_0c0s7a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l56;	.
+:c0_0c0s7a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s7a0l57;	.
+:c0_0c0s7a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s7n0;
+	logset:endPointOf :linkc0_0c0s7a0l50;
+	logset:endPointOf :linkc0_0c0s7a0l51;	.
+:c0_0c0s7a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s7n1;
+	logset:endPointOf :linkc0_0c0s7a0l52;
+	logset:endPointOf :linkc0_0c0s7a0l53;	.
+:c0_0c0s7a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s7n2;
+	logset:endPointOf :linkc0_0c0s7a0l54;
+	logset:endPointOf :linkc0_0c0s7a0l55;	.
+:c0_0c0s7a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s7n3;
+	logset:endPointOf :linkc0_0c0s7a0l56;
+	logset:endPointOf :linkc0_0c0s7a0l57;	.
+:c0_0c0s7n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s7n0;	.
+:c0_0c0s7n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s7n1;	.
+:c0_0c0s7n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s7n2;	.
+:c0_0c0s7n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s7n3;	.
+:c0_0c0s8a0l00 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l07 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l10 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l11 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l17;	.
+:c0_0c0s8a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l20;	.
+:c0_0c0s8a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l21;	.
+:c0_0c0s8a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l22;	.
+:c0_0c0s8a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l23;	.
+:c0_0c0s8a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l24;	.
+:c0_0c0s8a0l25 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l26;	.
+:c0_0c0s8a0l27 a craydict:NetworkTile ;	.
+:c0_0c0s8a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l30;	.
+:c0_0c0s8a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l31;	.
+:c0_0c0s8a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l32;	.
+:c0_0c0s8a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l33;	.
+:c0_0c0s8a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l43;	.
+:c0_0c0s8a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l32;	.
+:c0_0c0s8a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l40;	.
+:c0_0c0s8a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l41;	.
+:c0_0c0s8a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l40;	.
+:c0_0c0s8a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l41;	.
+:c0_0c0s8a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l42;	.
+:c0_0c0s8a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l43;	.
+:c0_0c0s8a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l41;	.
+:c0_0c0s8a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l30;	.
+:c0_0c0s8a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l41;	.
+:c0_0c0s8a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l40;	.
+:c0_0c0s8a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l50;	.
+:c0_0c0s8a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l51;	.
+:c0_0c0s8a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l52;	.
+:c0_0c0s8a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l53;	.
+:c0_0c0s8a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l54;	.
+:c0_0c0s8a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l55;	.
+:c0_0c0s8a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l56;	.
+:c0_0c0s8a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s8a0l57;	.
+:c0_0c0s8a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s8n0;
+	logset:endPointOf :linkc0_0c0s8a0l50;
+	logset:endPointOf :linkc0_0c0s8a0l51;	.
+:c0_0c0s8a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s8n1;
+	logset:endPointOf :linkc0_0c0s8a0l52;
+	logset:endPointOf :linkc0_0c0s8a0l53;	.
+:c0_0c0s8a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s8n2;
+	logset:endPointOf :linkc0_0c0s8a0l54;
+	logset:endPointOf :linkc0_0c0s8a0l55;	.
+:c0_0c0s8a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s8n3;
+	logset:endPointOf :linkc0_0c0s8a0l56;
+	logset:endPointOf :linkc0_0c0s8a0l57;	.
+:c0_0c0s8n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s8n0;	.
+:c0_0c0s8n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s8n1;	.
+:c0_0c0s8n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s8n2;	.
+:c0_0c0s8n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s8n3;	.
+:c0_0c0s9a0l00 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l01 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l02 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l03 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l04 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l05 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l06 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l07;	.
+:c0_0c0s9a0l10 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l11 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l12 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l13 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l14 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l15 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l16 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l17 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l20;	.
+:c0_0c0s9a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l21;	.
+:c0_0c0s9a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l22;	.
+:c0_0c0s9a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l23;	.
+:c0_0c0s9a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l24;	.
+:c0_0c0s9a0l25 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l26 a craydict:NetworkTile ;	.
+:c0_0c0s9a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l24;	.
+:c0_0c0s9a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l30;	.
+:c0_0c0s9a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l31;	.
+:c0_0c0s9a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l32;	.
+:c0_0c0s9a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l33;	.
+:c0_0c0s9a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l43;	.
+:c0_0c0s9a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l32;	.
+:c0_0c0s9a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l33;	.
+:c0_0c0s9a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l31;	.
+:c0_0c0s9a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l40;	.
+:c0_0c0s9a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l41;	.
+:c0_0c0s9a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l42;	.
+:c0_0c0s9a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l43;	.
+:c0_0c0s9a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l40;	.
+:c0_0c0s9a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l30;	.
+:c0_0c0s9a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l41;	.
+:c0_0c0s9a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l40;	.
+:c0_0c0s9a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l50;	.
+:c0_0c0s9a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l51;	.
+:c0_0c0s9a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l52;	.
+:c0_0c0s9a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l53;	.
+:c0_0c0s9a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l54;	.
+:c0_0c0s9a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l55;	.
+:c0_0c0s9a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l56;	.
+:c0_0c0s9a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c0s9a0l57;	.
+:c0_0c0s9a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s9n0;
+	logset:endPointOf :linkc0_0c0s9a0l50;
+	logset:endPointOf :linkc0_0c0s9a0l51;	.
+:c0_0c0s9a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s9n1;
+	logset:endPointOf :linkc0_0c0s9a0l52;
+	logset:endPointOf :linkc0_0c0s9a0l53;	.
+:c0_0c0s9a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s9n2;
+	logset:endPointOf :linkc0_0c0s9a0l54;
+	logset:endPointOf :linkc0_0c0s9a0l55;	.
+:c0_0c0s9a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c0s9n3;
+	logset:endPointOf :linkc0_0c0s9a0l56;
+	logset:endPointOf :linkc0_0c0s9a0l57;	.
+:c0_0c0s9n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s9n0;	.
+:c0_0c0s9n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s9n1;	.
+:c0_0c0s9n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s9n2;	.
+:c0_0c0s9n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c0s9n3;	.
+:c0_0c1s0a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l00;	.
+:c0_0c1s0a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l07;	.
+:c0_0c1s0a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l10;	.
+:c0_0c1s0a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l11;	.
+:c0_0c1s0a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l16;	.
+:c0_0c1s0a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l17;	.
+:c0_0c1s0a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l20;	.
+:c0_0c1s0a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l21;	.
+:c0_0c1s0a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l22;	.
+:c0_0c1s0a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l23;	.
+:c0_0c1s0a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s0a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l27;	.
+:c0_0c1s0a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l30;	.
+:c0_0c1s0a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l31;	.
+:c0_0c1s0a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l32;	.
+:c0_0c1s0a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l33;	.
+:c0_0c1s0a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l34;	.
+:c0_0c1s0a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l47;	.
+:c0_0c1s0a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l46;	.
+:c0_0c1s0a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l37;	.
+:c0_0c1s0a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l40;	.
+:c0_0c1s0a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l41;	.
+:c0_0c1s0a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l42;	.
+:c0_0c1s0a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l43;	.
+:c0_0c1s0a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l44;	.
+:c0_0c1s0a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l37;	.
+:c0_0c1s0a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l46;	.
+:c0_0c1s0a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l47;	.
+:c0_0c1s0a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l50;	.
+:c0_0c1s0a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l51;	.
+:c0_0c1s0a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l52;	.
+:c0_0c1s0a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l53;	.
+:c0_0c1s0a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l54;	.
+:c0_0c1s0a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l55;	.
+:c0_0c1s0a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l56;	.
+:c0_0c1s0a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s0a0l57;	.
+:c0_0c1s0a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s0n0;
+	logset:endPointOf :linkc0_0c1s0a0l50;
+	logset:endPointOf :linkc0_0c1s0a0l51;	.
+:c0_0c1s0a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s0n1;
+	logset:endPointOf :linkc0_0c1s0a0l52;
+	logset:endPointOf :linkc0_0c1s0a0l53;	.
+:c0_0c1s0a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s0n2;
+	logset:endPointOf :linkc0_0c1s0a0l54;
+	logset:endPointOf :linkc0_0c1s0a0l55;	.
+:c0_0c1s0a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s0n3;
+	logset:endPointOf :linkc0_0c1s0a0l56;
+	logset:endPointOf :linkc0_0c1s0a0l57;	.
+:c0_0c1s0n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s0n0;	.
+:c0_0c1s0n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s0n1;	.
+:c0_0c1s0n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s0n2;	.
+:c0_0c1s0n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s0n3;	.
+:c0_0c1s10a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l00;	.
+:c0_0c1s10a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l07;	.
+:c0_0c1s10a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l10;	.
+:c0_0c1s10a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l11;	.
+:c0_0c1s10a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l16;	.
+:c0_0c1s10a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l17;	.
+:c0_0c1s10a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l20;	.
+:c0_0c1s10a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s10a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l24;	.
+:c0_0c1s10a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l25;	.
+:c0_0c1s10a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l26;	.
+:c0_0c1s10a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l24;	.
+:c0_0c1s10a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l30;	.
+:c0_0c1s10a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l40;	.
+:c0_0c1s10a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l30;	.
+:c0_0c1s10a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l33;	.
+:c0_0c1s10a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l32;	.
+:c0_0c1s10a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l30;	.
+:c0_0c1s10a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l31;	.
+:c0_0c1s10a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l40;	.
+:c0_0c1s10a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l40;	.
+:c0_0c1s10a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l41;	.
+:c0_0c1s10a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l41;	.
+:c0_0c1s10a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l43;	.
+:c0_0c1s10a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l33;	.
+:c0_0c1s10a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l43;	.
+:c0_0c1s10a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l41;	.
+:c0_0c1s10a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l41;	.
+:c0_0c1s10a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l50;	.
+:c0_0c1s10a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l51;	.
+:c0_0c1s10a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l52;	.
+:c0_0c1s10a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l53;	.
+:c0_0c1s10a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l54;	.
+:c0_0c1s10a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l55;	.
+:c0_0c1s10a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l56;	.
+:c0_0c1s10a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s10a0l57;	.
+:c0_0c1s10a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s10n0;
+	logset:endPointOf :linkc0_0c1s10a0l50;
+	logset:endPointOf :linkc0_0c1s10a0l51;	.
+:c0_0c1s10a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s10n1;
+	logset:endPointOf :linkc0_0c1s10a0l52;
+	logset:endPointOf :linkc0_0c1s10a0l53;	.
+:c0_0c1s10a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s10n2;
+	logset:endPointOf :linkc0_0c1s10a0l54;
+	logset:endPointOf :linkc0_0c1s10a0l55;	.
+:c0_0c1s10a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s10n3;
+	logset:endPointOf :linkc0_0c1s10a0l56;
+	logset:endPointOf :linkc0_0c1s10a0l57;	.
+:c0_0c1s10n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s10n0;	.
+:c0_0c1s10n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s10n1;	.
+:c0_0c1s10n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s10n2;	.
+:c0_0c1s10n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s10n3;	.
+:c0_0c1s11a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l00;	.
+:c0_0c1s11a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l07;	.
+:c0_0c1s11a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l10;	.
+:c0_0c1s11a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l11;	.
+:c0_0c1s11a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l07;	.
+:c0_0c1s11a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l17;	.
+:c0_0c1s11a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l20;	.
+:c0_0c1s11a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s11a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l24;	.
+:c0_0c1s11a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l17;	.
+:c0_0c1s11a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l26;	.
+:c0_0c1s11a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l24;	.
+:c0_0c1s11a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l30;	.
+:c0_0c1s11a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l40;	.
+:c0_0c1s11a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l30;	.
+:c0_0c1s11a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l33;	.
+:c0_0c1s11a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l43;	.
+:c0_0c1s11a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l41;	.
+:c0_0c1s11a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l43;	.
+:c0_0c1s11a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l31;	.
+:c0_0c1s11a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l40;	.
+:c0_0c1s11a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l41;	.
+:c0_0c1s11a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l41;	.
+:c0_0c1s11a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l43;	.
+:c0_0c1s11a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l33;	.
+:c0_0c1s11a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l30;	.
+:c0_0c1s11a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l42;	.
+:c0_0c1s11a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l42;	.
+:c0_0c1s11a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l50;	.
+:c0_0c1s11a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l51;	.
+:c0_0c1s11a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l52;	.
+:c0_0c1s11a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l53;	.
+:c0_0c1s11a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l54;	.
+:c0_0c1s11a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l55;	.
+:c0_0c1s11a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l56;	.
+:c0_0c1s11a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s11a0l57;	.
+:c0_0c1s11a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s11n0;
+	logset:endPointOf :linkc0_0c1s11a0l50;
+	logset:endPointOf :linkc0_0c1s11a0l51;	.
+:c0_0c1s11a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s11n1;
+	logset:endPointOf :linkc0_0c1s11a0l52;
+	logset:endPointOf :linkc0_0c1s11a0l53;	.
+:c0_0c1s11a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s11n2;
+	logset:endPointOf :linkc0_0c1s11a0l54;
+	logset:endPointOf :linkc0_0c1s11a0l55;	.
+:c0_0c1s11a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s11n3;
+	logset:endPointOf :linkc0_0c1s11a0l56;
+	logset:endPointOf :linkc0_0c1s11a0l57;	.
+:c0_0c1s11n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s11n0;	.
+:c0_0c1s11n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s11n1;	.
+:c0_0c1s11n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s11n2;	.
+:c0_0c1s11n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s11n3;	.
+:c0_0c1s12a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l00;	.
+:c0_0c1s12a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l26;	.
+:c0_0c1s12a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l10;	.
+:c0_0c1s12a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l11;	.
+:c0_0c1s12a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l16;	.
+:c0_0c1s12a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l17;	.
+:c0_0c1s12a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l20;	.
+:c0_0c1s12a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l24;	.
+:c0_0c1s12a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l27;	.
+:c0_0c1s12a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l26;	.
+:c0_0c1s12a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l24;	.
+:c0_0c1s12a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l30;	.
+:c0_0c1s12a0l31 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l32 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l33;	.
+:c0_0c1s12a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l32;	.
+:c0_0c1s12a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l31;	.
+:c0_0c1s12a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l42;	.
+:c0_0c1s12a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l31;	.
+:c0_0c1s12a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l40;	.
+:c0_0c1s12a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l41;	.
+:c0_0c1s12a0l42 a craydict:NetworkTile ;	.
+:c0_0c1s12a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l43;	.
+:c0_0c1s12a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l33;	.
+:c0_0c1s12a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l30;	.
+:c0_0c1s12a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l32;	.
+:c0_0c1s12a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l40;	.
+:c0_0c1s12a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l50;	.
+:c0_0c1s12a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l51;	.
+:c0_0c1s12a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l52;	.
+:c0_0c1s12a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l53;	.
+:c0_0c1s12a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l54;	.
+:c0_0c1s12a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l55;	.
+:c0_0c1s12a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l56;	.
+:c0_0c1s12a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s12a0l57;	.
+:c0_0c1s12a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s12n0;
+	logset:endPointOf :linkc0_0c1s12a0l50;
+	logset:endPointOf :linkc0_0c1s12a0l51;	.
+:c0_0c1s12a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s12n1;
+	logset:endPointOf :linkc0_0c1s12a0l52;
+	logset:endPointOf :linkc0_0c1s12a0l53;	.
+:c0_0c1s12a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s12n2;
+	logset:endPointOf :linkc0_0c1s12a0l54;
+	logset:endPointOf :linkc0_0c1s12a0l55;	.
+:c0_0c1s12a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s12n3;
+	logset:endPointOf :linkc0_0c1s12a0l56;
+	logset:endPointOf :linkc0_0c1s12a0l57;	.
+:c0_0c1s12n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s12n0;	.
+:c0_0c1s12n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s12n1;	.
+:c0_0c1s12n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s12n2;	.
+:c0_0c1s12n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s12n3;	.
+:c0_0c1s13a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l00;	.
+:c0_0c1s13a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l16;	.
+:c0_0c1s13a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l10;	.
+:c0_0c1s13a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l11;	.
+:c0_0c1s13a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l07;	.
+:c0_0c1s13a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l25;	.
+:c0_0c1s13a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l20;	.
+:c0_0c1s13a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l24;	.
+:c0_0c1s13a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l25;	.
+:c0_0c1s13a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l25;	.
+:c0_0c1s13a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l24;	.
+:c0_0c1s13a0l30 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l31 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l32 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l33;	.
+:c0_0c1s13a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l32;	.
+:c0_0c1s13a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l42;	.
+:c0_0c1s13a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l43;	.
+:c0_0c1s13a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l40;	.
+:c0_0c1s13a0l40 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l41 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l42 a craydict:NetworkTile ;	.
+:c0_0c1s13a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l43;	.
+:c0_0c1s13a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l33;	.
+:c0_0c1s13a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l30;	.
+:c0_0c1s13a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l33;	.
+:c0_0c1s13a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l33;	.
+:c0_0c1s13a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l50;	.
+:c0_0c1s13a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l51;	.
+:c0_0c1s13a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l52;	.
+:c0_0c1s13a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l53;	.
+:c0_0c1s13a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l54;	.
+:c0_0c1s13a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l55;	.
+:c0_0c1s13a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l56;	.
+:c0_0c1s13a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s13a0l57;	.
+:c0_0c1s13a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s13n0;
+	logset:endPointOf :linkc0_0c1s13a0l50;
+	logset:endPointOf :linkc0_0c1s13a0l51;	.
+:c0_0c1s13a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s13n1;
+	logset:endPointOf :linkc0_0c1s13a0l52;
+	logset:endPointOf :linkc0_0c1s13a0l53;	.
+:c0_0c1s13a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s13n2;
+	logset:endPointOf :linkc0_0c1s13a0l54;
+	logset:endPointOf :linkc0_0c1s13a0l55;	.
+:c0_0c1s13a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s13n3;
+	logset:endPointOf :linkc0_0c1s13a0l56;
+	logset:endPointOf :linkc0_0c1s13a0l57;	.
+:c0_0c1s13n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s13n0;	.
+:c0_0c1s13n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s13n1;	.
+:c0_0c1s13n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s13n2;	.
+:c0_0c1s13n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s13n3;	.
+:c0_0c1s14a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l00;	.
+:c0_0c1s14a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l17;	.
+:c0_0c1s14a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l10;	.
+:c0_0c1s14a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l11;	.
+:c0_0c1s14a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l07;	.
+:c0_0c1s14a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l07;	.
+:c0_0c1s14a0l20 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l24;	.
+:c0_0c1s14a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l17;	.
+:c0_0c1s14a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l17;	.
+:c0_0c1s14a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l24;	.
+:c0_0c1s14a0l30 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l31 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l32 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l33 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l43;	.
+:c0_0c1s14a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l42;	.
+:c0_0c1s14a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l43;	.
+:c0_0c1s14a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l32;	.
+:c0_0c1s14a0l40 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l41 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l42 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l43 a craydict:NetworkTile ;	.
+:c0_0c1s14a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l33;	.
+:c0_0c1s14a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l31;	.
+:c0_0c1s14a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l41;	.
+:c0_0c1s14a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l31;	.
+:c0_0c1s14a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l50;	.
+:c0_0c1s14a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l51;	.
+:c0_0c1s14a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l52;	.
+:c0_0c1s14a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l53;	.
+:c0_0c1s14a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l54;	.
+:c0_0c1s14a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l55;	.
+:c0_0c1s14a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l56;	.
+:c0_0c1s14a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s14a0l57;	.
+:c0_0c1s14a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s14n0;
+	logset:endPointOf :linkc0_0c1s14a0l50;
+	logset:endPointOf :linkc0_0c1s14a0l51;	.
+:c0_0c1s14a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s14n1;
+	logset:endPointOf :linkc0_0c1s14a0l52;
+	logset:endPointOf :linkc0_0c1s14a0l53;	.
+:c0_0c1s14a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s14n2;
+	logset:endPointOf :linkc0_0c1s14a0l54;
+	logset:endPointOf :linkc0_0c1s14a0l55;	.
+:c0_0c1s14a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s14n3;
+	logset:endPointOf :linkc0_0c1s14a0l56;
+	logset:endPointOf :linkc0_0c1s14a0l57;	.
+:c0_0c1s14n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s14n0;	.
+:c0_0c1s14n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s14n1;	.
+:c0_0c1s14n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s14n2;	.
+:c0_0c1s14n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s14n3;	.
+:c0_0c1s15a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l00;	.
+:c0_0c1s15a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l16;	.
+:c0_0c1s15a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l10;	.
+:c0_0c1s15a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l11;	.
+:c0_0c1s15a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l25;	.
+:c0_0c1s15a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l26;	.
+:c0_0c1s15a0l20 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l25;	.
+:c0_0c1s15a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l26;	.
+:c0_0c1s15a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l17;	.
+:c0_0c1s15a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l24;	.
+:c0_0c1s15a0l30 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l31 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l32 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l33 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l30;	.
+:c0_0c1s15a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l42;	.
+:c0_0c1s15a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l31;	.
+:c0_0c1s15a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l42;	.
+:c0_0c1s15a0l40 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l41 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l42 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l43 a craydict:NetworkTile ;	.
+:c0_0c1s15a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l32;	.
+:c0_0c1s15a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l30;	.
+:c0_0c1s15a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l42;	.
+:c0_0c1s15a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l40;	.
+:c0_0c1s15a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l50;	.
+:c0_0c1s15a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l51;	.
+:c0_0c1s15a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l52;	.
+:c0_0c1s15a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l53;	.
+:c0_0c1s15a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l54;	.
+:c0_0c1s15a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l55;	.
+:c0_0c1s15a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l56;	.
+:c0_0c1s15a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s15a0l57;	.
+:c0_0c1s15a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s15n0;
+	logset:endPointOf :linkc0_0c1s15a0l50;
+	logset:endPointOf :linkc0_0c1s15a0l51;	.
+:c0_0c1s15a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s15n1;
+	logset:endPointOf :linkc0_0c1s15a0l52;
+	logset:endPointOf :linkc0_0c1s15a0l53;	.
+:c0_0c1s15a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s15n2;
+	logset:endPointOf :linkc0_0c1s15a0l54;
+	logset:endPointOf :linkc0_0c1s15a0l55;	.
+:c0_0c1s15a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s15n3;
+	logset:endPointOf :linkc0_0c1s15a0l56;
+	logset:endPointOf :linkc0_0c1s15a0l57;	.
+:c0_0c1s15n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s15n0;	.
+:c0_0c1s15n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s15n1;	.
+:c0_0c1s15n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s15n2;	.
+:c0_0c1s15n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s15n3;	.
+:c0_0c1s1a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l00;	.
+:c0_0c1s1a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l07;	.
+:c0_0c1s1a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l10;	.
+:c0_0c1s1a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l11;	.
+:c0_0c1s1a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l16;	.
+:c0_0c1s1a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l17;	.
+:c0_0c1s1a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l23;	.
+:c0_0c1s1a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l21;	.
+:c0_0c1s1a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l22;	.
+:c0_0c1s1a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l23;	.
+:c0_0c1s1a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s1a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l27;	.
+:c0_0c1s1a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l30;	.
+:c0_0c1s1a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l31;	.
+:c0_0c1s1a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l32;	.
+:c0_0c1s1a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l33;	.
+:c0_0c1s1a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l34;	.
+:c0_0c1s1a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l47;	.
+:c0_0c1s1a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l46;	.
+:c0_0c1s1a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l37;	.
+:c0_0c1s1a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l40;	.
+:c0_0c1s1a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l41;	.
+:c0_0c1s1a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l42;	.
+:c0_0c1s1a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l43;	.
+:c0_0c1s1a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l44;	.
+:c0_0c1s1a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l37;	.
+:c0_0c1s1a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l46;	.
+:c0_0c1s1a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l47;	.
+:c0_0c1s1a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l50;	.
+:c0_0c1s1a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l51;	.
+:c0_0c1s1a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l52;	.
+:c0_0c1s1a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l53;	.
+:c0_0c1s1a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l54;	.
+:c0_0c1s1a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l55;	.
+:c0_0c1s1a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l56;	.
+:c0_0c1s1a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s1a0l57;	.
+:c0_0c1s1a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s1n0;
+	logset:endPointOf :linkc0_0c1s1a0l50;
+	logset:endPointOf :linkc0_0c1s1a0l51;	.
+:c0_0c1s1a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s1n1;
+	logset:endPointOf :linkc0_0c1s1a0l52;
+	logset:endPointOf :linkc0_0c1s1a0l53;	.
+:c0_0c1s1a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s1n2;
+	logset:endPointOf :linkc0_0c1s1a0l54;
+	logset:endPointOf :linkc0_0c1s1a0l55;	.
+:c0_0c1s1a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s1n3;
+	logset:endPointOf :linkc0_0c1s1a0l56;
+	logset:endPointOf :linkc0_0c1s1a0l57;	.
+:c0_0c1s1n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s1n0;	.
+:c0_0c1s1n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s1n1;	.
+:c0_0c1s1n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s1n2;	.
+:c0_0c1s1n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s1n3;	.
+:c0_0c1s2a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l00;	.
+:c0_0c1s2a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l07;	.
+:c0_0c1s2a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l10;	.
+:c0_0c1s2a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l11;	.
+:c0_0c1s2a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l16;	.
+:c0_0c1s2a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l17;	.
+:c0_0c1s2a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l23;	.
+:c0_0c1s2a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l10;	.
+:c0_0c1s2a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l22;	.
+:c0_0c1s2a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l23;	.
+:c0_0c1s2a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s2a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l27;	.
+:c0_0c1s2a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l30;	.
+:c0_0c1s2a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l31;	.
+:c0_0c1s2a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l32;	.
+:c0_0c1s2a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l33;	.
+:c0_0c1s2a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l34;	.
+:c0_0c1s2a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l47;	.
+:c0_0c1s2a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l46;	.
+:c0_0c1s2a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l37;	.
+:c0_0c1s2a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l40;	.
+:c0_0c1s2a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l41;	.
+:c0_0c1s2a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l42;	.
+:c0_0c1s2a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l43;	.
+:c0_0c1s2a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l44;	.
+:c0_0c1s2a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l37;	.
+:c0_0c1s2a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l46;	.
+:c0_0c1s2a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l47;	.
+:c0_0c1s2a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l50;	.
+:c0_0c1s2a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l51;	.
+:c0_0c1s2a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l52;	.
+:c0_0c1s2a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l53;	.
+:c0_0c1s2a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l54;	.
+:c0_0c1s2a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l55;	.
+:c0_0c1s2a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l56;	.
+:c0_0c1s2a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s2a0l57;	.
+:c0_0c1s2a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s2n0;
+	logset:endPointOf :linkc0_0c1s2a0l50;
+	logset:endPointOf :linkc0_0c1s2a0l51;	.
+:c0_0c1s2a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s2n1;
+	logset:endPointOf :linkc0_0c1s2a0l52;
+	logset:endPointOf :linkc0_0c1s2a0l53;	.
+:c0_0c1s2a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s2n2;
+	logset:endPointOf :linkc0_0c1s2a0l54;
+	logset:endPointOf :linkc0_0c1s2a0l55;	.
+:c0_0c1s2a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s2n3;
+	logset:endPointOf :linkc0_0c1s2a0l56;
+	logset:endPointOf :linkc0_0c1s2a0l57;	.
+:c0_0c1s2n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s2n0;	.
+:c0_0c1s2n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s2n1;	.
+:c0_0c1s2n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s2n2;	.
+:c0_0c1s2n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s2n3;	.
+:c0_0c1s3a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l00;	.
+:c0_0c1s3a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l07;	.
+:c0_0c1s3a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l10;	.
+:c0_0c1s3a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l00;	.
+:c0_0c1s3a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l16;	.
+:c0_0c1s3a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l17;	.
+:c0_0c1s3a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l23;	.
+:c0_0c1s3a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l21;	.
+:c0_0c1s3a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l21;	.
+:c0_0c1s3a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l23;	.
+:c0_0c1s3a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s3a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l27;	.
+:c0_0c1s3a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l30;	.
+:c0_0c1s3a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l31;	.
+:c0_0c1s3a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l32;	.
+:c0_0c1s3a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l33;	.
+:c0_0c1s3a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l34;	.
+:c0_0c1s3a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l47;	.
+:c0_0c1s3a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l46;	.
+:c0_0c1s3a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l37;	.
+:c0_0c1s3a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l40;	.
+:c0_0c1s3a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l41;	.
+:c0_0c1s3a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l42;	.
+:c0_0c1s3a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l43;	.
+:c0_0c1s3a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l44;	.
+:c0_0c1s3a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l37;	.
+:c0_0c1s3a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l46;	.
+:c0_0c1s3a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l47;	.
+:c0_0c1s3a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l50;	.
+:c0_0c1s3a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l51;	.
+:c0_0c1s3a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l52;	.
+:c0_0c1s3a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l53;	.
+:c0_0c1s3a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l54;	.
+:c0_0c1s3a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l55;	.
+:c0_0c1s3a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l56;	.
+:c0_0c1s3a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s3a0l57;	.
+:c0_0c1s3a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s3n0;
+	logset:endPointOf :linkc0_0c1s3a0l50;
+	logset:endPointOf :linkc0_0c1s3a0l51;	.
+:c0_0c1s3a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s3n1;
+	logset:endPointOf :linkc0_0c1s3a0l52;
+	logset:endPointOf :linkc0_0c1s3a0l53;	.
+:c0_0c1s3a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s3n2;
+	logset:endPointOf :linkc0_0c1s3a0l54;
+	logset:endPointOf :linkc0_0c1s3a0l55;	.
+:c0_0c1s3a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s3n3;
+	logset:endPointOf :linkc0_0c1s3a0l56;
+	logset:endPointOf :linkc0_0c1s3a0l57;	.
+:c0_0c1s3n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s3n0;	.
+:c0_0c1s3n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s3n1;	.
+:c0_0c1s3n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s3n2;	.
+:c0_0c1s3n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s3n3;	.
+:c0_0c1s4a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l21;	.
+:c0_0c1s4a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l07;	.
+:c0_0c1s4a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l10;	.
+:c0_0c1s4a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l11;	.
+:c0_0c1s4a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l16;	.
+:c0_0c1s4a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l17;	.
+:c0_0c1s4a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l23;	.
+:c0_0c1s4a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l21;	.
+:c0_0c1s4a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l20;	.
+:c0_0c1s4a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l23;	.
+:c0_0c1s4a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s4a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l27;	.
+:c0_0c1s4a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l30;	.
+:c0_0c1s4a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l31;	.
+:c0_0c1s4a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l32;	.
+:c0_0c1s4a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l33;	.
+:c0_0c1s4a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l34;	.
+:c0_0c1s4a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l47;	.
+:c0_0c1s4a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l46;	.
+:c0_0c1s4a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l37;	.
+:c0_0c1s4a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l40;	.
+:c0_0c1s4a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l41;	.
+:c0_0c1s4a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l42;	.
+:c0_0c1s4a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l43;	.
+:c0_0c1s4a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l44;	.
+:c0_0c1s4a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l37;	.
+:c0_0c1s4a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l46;	.
+:c0_0c1s4a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l47;	.
+:c0_0c1s4a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l50;	.
+:c0_0c1s4a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l51;	.
+:c0_0c1s4a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l52;	.
+:c0_0c1s4a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l53;	.
+:c0_0c1s4a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l54;	.
+:c0_0c1s4a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l55;	.
+:c0_0c1s4a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l56;	.
+:c0_0c1s4a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s4a0l57;	.
+:c0_0c1s4a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s4n0;
+	logset:endPointOf :linkc0_0c1s4a0l50;
+	logset:endPointOf :linkc0_0c1s4a0l51;	.
+:c0_0c1s4a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s4n1;
+	logset:endPointOf :linkc0_0c1s4a0l52;
+	logset:endPointOf :linkc0_0c1s4a0l53;	.
+:c0_0c1s4a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s4n2;
+	logset:endPointOf :linkc0_0c1s4a0l54;
+	logset:endPointOf :linkc0_0c1s4a0l55;	.
+:c0_0c1s4a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s4n3;
+	logset:endPointOf :linkc0_0c1s4a0l56;
+	logset:endPointOf :linkc0_0c1s4a0l57;	.
+:c0_0c1s4n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s4n0;	.
+:c0_0c1s4n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s4n1;	.
+:c0_0c1s4n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s4n2;	.
+:c0_0c1s4n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s4n3;	.
+:c0_0c1s5a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l11;	.
+:c0_0c1s5a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l07;	.
+:c0_0c1s5a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l22;	.
+:c0_0c1s5a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l00;	.
+:c0_0c1s5a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l16;	.
+:c0_0c1s5a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l17;	.
+:c0_0c1s5a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l23;	.
+:c0_0c1s5a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l22;	.
+:c0_0c1s5a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l22;	.
+:c0_0c1s5a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l23;	.
+:c0_0c1s5a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l27;	.
+:c0_0c1s5a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l30;	.
+:c0_0c1s5a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l31;	.
+:c0_0c1s5a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l32;	.
+:c0_0c1s5a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l33;	.
+:c0_0c1s5a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l34;	.
+:c0_0c1s5a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l47;	.
+:c0_0c1s5a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l46;	.
+:c0_0c1s5a0l37 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l40;	.
+:c0_0c1s5a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l41;	.
+:c0_0c1s5a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l42;	.
+:c0_0c1s5a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l43;	.
+:c0_0c1s5a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l44;	.
+:c0_0c1s5a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l37;	.
+:c0_0c1s5a0l46 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l47 a craydict:NetworkTile ;	.
+:c0_0c1s5a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l50;	.
+:c0_0c1s5a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l51;	.
+:c0_0c1s5a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l52;	.
+:c0_0c1s5a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l53;	.
+:c0_0c1s5a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l54;	.
+:c0_0c1s5a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l55;	.
+:c0_0c1s5a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l56;	.
+:c0_0c1s5a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s5a0l57;	.
+:c0_0c1s5a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s5n0;
+	logset:endPointOf :linkc0_0c1s5a0l50;
+	logset:endPointOf :linkc0_0c1s5a0l51;	.
+:c0_0c1s5a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s5n1;
+	logset:endPointOf :linkc0_0c1s5a0l52;
+	logset:endPointOf :linkc0_0c1s5a0l53;	.
+:c0_0c1s5a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s5n2;
+	logset:endPointOf :linkc0_0c1s5a0l54;
+	logset:endPointOf :linkc0_0c1s5a0l55;	.
+:c0_0c1s5a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s5n3;
+	logset:endPointOf :linkc0_0c1s5a0l56;
+	logset:endPointOf :linkc0_0c1s5a0l57;	.
+:c0_0c1s5n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s5n0;	.
+:c0_0c1s5n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s5n1;	.
+:c0_0c1s5n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s5n2;	.
+:c0_0c1s5n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s5n3;	.
+:c0_0c1s6a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l10;	.
+:c0_0c1s6a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l07;	.
+:c0_0c1s6a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l00;	.
+:c0_0c1s6a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l00;	.
+:c0_0c1s6a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l16;	.
+:c0_0c1s6a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l17;	.
+:c0_0c1s6a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l23;	.
+:c0_0c1s6a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l10;	.
+:c0_0c1s6a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l10;	.
+:c0_0c1s6a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l23;	.
+:c0_0c1s6a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l27;	.
+:c0_0c1s6a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l30;	.
+:c0_0c1s6a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l31;	.
+:c0_0c1s6a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l32;	.
+:c0_0c1s6a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l33;	.
+:c0_0c1s6a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l34;	.
+:c0_0c1s6a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l47;	.
+:c0_0c1s6a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l46;	.
+:c0_0c1s6a0l37 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l40;	.
+:c0_0c1s6a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l41;	.
+:c0_0c1s6a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l42;	.
+:c0_0c1s6a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l43;	.
+:c0_0c1s6a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l44;	.
+:c0_0c1s6a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l37;	.
+:c0_0c1s6a0l46 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l47 a craydict:NetworkTile ;	.
+:c0_0c1s6a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l50;	.
+:c0_0c1s6a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l51;	.
+:c0_0c1s6a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l52;	.
+:c0_0c1s6a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l53;	.
+:c0_0c1s6a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l54;	.
+:c0_0c1s6a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l55;	.
+:c0_0c1s6a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l56;	.
+:c0_0c1s6a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s6a0l57;	.
+:c0_0c1s6a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s6n0;
+	logset:endPointOf :linkc0_0c1s6a0l50;
+	logset:endPointOf :linkc0_0c1s6a0l51;	.
+:c0_0c1s6a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s6n1;
+	logset:endPointOf :linkc0_0c1s6a0l52;
+	logset:endPointOf :linkc0_0c1s6a0l53;	.
+:c0_0c1s6a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s6n2;
+	logset:endPointOf :linkc0_0c1s6a0l54;
+	logset:endPointOf :linkc0_0c1s6a0l55;	.
+:c0_0c1s6a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s6n3;
+	logset:endPointOf :linkc0_0c1s6a0l56;
+	logset:endPointOf :linkc0_0c1s6a0l57;	.
+:c0_0c1s6n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s6n0;	.
+:c0_0c1s6n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s6n1;	.
+:c0_0c1s6n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s6n2;	.
+:c0_0c1s6n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s6n3;	.
+:c0_0c1s7a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l11;	.
+:c0_0c1s7a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l07;	.
+:c0_0c1s7a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l21;	.
+:c0_0c1s7a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l22;	.
+:c0_0c1s7a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l16;	.
+:c0_0c1s7a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l17;	.
+:c0_0c1s7a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l23;	.
+:c0_0c1s7a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l10;	.
+:c0_0c1s7a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l21;	.
+:c0_0c1s7a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l22;	.
+:c0_0c1s7a0l24 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l25 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l26 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l27;	.
+:c0_0c1s7a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l30;	.
+:c0_0c1s7a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l31;	.
+:c0_0c1s7a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l32;	.
+:c0_0c1s7a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l33;	.
+:c0_0c1s7a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l34;	.
+:c0_0c1s7a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l47;	.
+:c0_0c1s7a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l46;	.
+:c0_0c1s7a0l37 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l40;	.
+:c0_0c1s7a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l41;	.
+:c0_0c1s7a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l42;	.
+:c0_0c1s7a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l43;	.
+:c0_0c1s7a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l44;	.
+:c0_0c1s7a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l37;	.
+:c0_0c1s7a0l46 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l47 a craydict:NetworkTile ;	.
+:c0_0c1s7a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l50;	.
+:c0_0c1s7a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l51;	.
+:c0_0c1s7a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l52;	.
+:c0_0c1s7a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l53;	.
+:c0_0c1s7a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l54;	.
+:c0_0c1s7a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l55;	.
+:c0_0c1s7a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l56;	.
+:c0_0c1s7a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s7a0l57;	.
+:c0_0c1s7a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s7n0;
+	logset:endPointOf :linkc0_0c1s7a0l50;
+	logset:endPointOf :linkc0_0c1s7a0l51;	.
+:c0_0c1s7a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s7n1;
+	logset:endPointOf :linkc0_0c1s7a0l52;
+	logset:endPointOf :linkc0_0c1s7a0l53;	.
+:c0_0c1s7a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s7n2;
+	logset:endPointOf :linkc0_0c1s7a0l54;
+	logset:endPointOf :linkc0_0c1s7a0l55;	.
+:c0_0c1s7a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s7n3;
+	logset:endPointOf :linkc0_0c1s7a0l56;
+	logset:endPointOf :linkc0_0c1s7a0l57;	.
+:c0_0c1s7n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s7n0;	.
+:c0_0c1s7n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s7n1;	.
+:c0_0c1s7n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s7n2;	.
+:c0_0c1s7n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s7n3;	.
+:c0_0c1s8a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l00;	.
+:c0_0c1s8a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l07;	.
+:c0_0c1s8a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l10;	.
+:c0_0c1s8a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l11;	.
+:c0_0c1s8a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l16;	.
+:c0_0c1s8a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l17;	.
+:c0_0c1s8a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l20;	.
+:c0_0c1s8a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s8a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l24;	.
+:c0_0c1s8a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l25;	.
+:c0_0c1s8a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l26;	.
+:c0_0c1s8a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l27;	.
+:c0_0c1s8a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l30;	.
+:c0_0c1s8a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l40;	.
+:c0_0c1s8a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l30;	.
+:c0_0c1s8a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l33;	.
+:c0_0c1s8a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l43;	.
+:c0_0c1s8a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l32;	.
+:c0_0c1s8a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l40;	.
+:c0_0c1s8a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l41;	.
+:c0_0c1s8a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l40;	.
+:c0_0c1s8a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l41;	.
+:c0_0c1s8a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l41;	.
+:c0_0c1s8a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l43;	.
+:c0_0c1s8a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l41;	.
+:c0_0c1s8a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l30;	.
+:c0_0c1s8a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l41;	.
+:c0_0c1s8a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l40;	.
+:c0_0c1s8a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l50;	.
+:c0_0c1s8a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l51;	.
+:c0_0c1s8a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l52;	.
+:c0_0c1s8a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l53;	.
+:c0_0c1s8a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l54;	.
+:c0_0c1s8a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l55;	.
+:c0_0c1s8a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l56;	.
+:c0_0c1s8a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s8a0l57;	.
+:c0_0c1s8a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s8n0;
+	logset:endPointOf :linkc0_0c1s8a0l50;
+	logset:endPointOf :linkc0_0c1s8a0l51;	.
+:c0_0c1s8a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s8n1;
+	logset:endPointOf :linkc0_0c1s8a0l52;
+	logset:endPointOf :linkc0_0c1s8a0l53;	.
+:c0_0c1s8a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s8n2;
+	logset:endPointOf :linkc0_0c1s8a0l54;
+	logset:endPointOf :linkc0_0c1s8a0l55;	.
+:c0_0c1s8a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s8n3;
+	logset:endPointOf :linkc0_0c1s8a0l56;
+	logset:endPointOf :linkc0_0c1s8a0l57;	.
+:c0_0c1s8n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s8n0;	.
+:c0_0c1s8n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s8n1;	.
+:c0_0c1s8n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s8n2;	.
+:c0_0c1s8n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s8n3;	.
+:c0_0c1s9a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l00;	.
+:c0_0c1s9a0l01 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l02 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l03 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l04 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l05 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l06 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l07;	.
+:c0_0c1s9a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l10;	.
+:c0_0c1s9a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l11;	.
+:c0_0c1s9a0l12 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l13 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l14 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l15 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l16;	.
+:c0_0c1s9a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l17;	.
+:c0_0c1s9a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l20;	.
+:c0_0c1s9a0l21 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l22 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l23 a craydict:NetworkTile ;	.
+:c0_0c1s9a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l24;	.
+:c0_0c1s9a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l25;	.
+:c0_0c1s9a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l26;	.
+:c0_0c1s9a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l24;	.
+:c0_0c1s9a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l30;	.
+:c0_0c1s9a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l40;	.
+:c0_0c1s9a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l30;	.
+:c0_0c1s9a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l33;	.
+:c0_0c1s9a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l43;	.
+:c0_0c1s9a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l32;	.
+:c0_0c1s9a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l33;	.
+:c0_0c1s9a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l31;	.
+:c0_0c1s9a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l40;	.
+:c0_0c1s9a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l41;	.
+:c0_0c1s9a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l41;	.
+:c0_0c1s9a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l43;	.
+:c0_0c1s9a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l40;	.
+:c0_0c1s9a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l30;	.
+:c0_0c1s9a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l41;	.
+:c0_0c1s9a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l40;	.
+:c0_0c1s9a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l50;	.
+:c0_0c1s9a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l51;	.
+:c0_0c1s9a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l52;	.
+:c0_0c1s9a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l53;	.
+:c0_0c1s9a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l54;	.
+:c0_0c1s9a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l55;	.
+:c0_0c1s9a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l56;	.
+:c0_0c1s9a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c1s9a0l57;	.
+:c0_0c1s9a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s9n0;
+	logset:endPointOf :linkc0_0c1s9a0l50;
+	logset:endPointOf :linkc0_0c1s9a0l51;	.
+:c0_0c1s9a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s9n1;
+	logset:endPointOf :linkc0_0c1s9a0l52;
+	logset:endPointOf :linkc0_0c1s9a0l53;	.
+:c0_0c1s9a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s9n2;
+	logset:endPointOf :linkc0_0c1s9a0l54;
+	logset:endPointOf :linkc0_0c1s9a0l55;	.
+:c0_0c1s9a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c1s9n3;
+	logset:endPointOf :linkc0_0c1s9a0l56;
+	logset:endPointOf :linkc0_0c1s9a0l57;	.
+:c0_0c1s9n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s9n0;	.
+:c0_0c1s9n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s9n1;	.
+:c0_0c1s9n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s9n2;	.
+:c0_0c1s9n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c1s9n3;	.
+:c0_0c2s0a0l00 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l07;	.
+:c0_0c2s0a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l10;	.
+:c0_0c2s0a0l11 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l16;	.
+:c0_0c2s0a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l17;	.
+:c0_0c2s0a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l20;	.
+:c0_0c2s0a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l21;	.
+:c0_0c2s0a0l22 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l23;	.
+:c0_0c2s0a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l24;	.
+:c0_0c2s0a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l25;	.
+:c0_0c2s0a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l26;	.
+:c0_0c2s0a0l27 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l30;	.
+:c0_0c2s0a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l31;	.
+:c0_0c2s0a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l32;	.
+:c0_0c2s0a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l33;	.
+:c0_0c2s0a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l45;	.
+:c0_0c2s0a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l36;	.
+:c0_0c2s0a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l47;	.
+:c0_0c2s0a0l40 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l41 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l42 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l43;	.
+:c0_0c2s0a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s0a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l35;	.
+:c0_0c2s0a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l46;	.
+:c0_0c2s0a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l37;	.
+:c0_0c2s0a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l50;	.
+:c0_0c2s0a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l51;	.
+:c0_0c2s0a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l52;	.
+:c0_0c2s0a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l53;	.
+:c0_0c2s0a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l54;	.
+:c0_0c2s0a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l55;	.
+:c0_0c2s0a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l56;	.
+:c0_0c2s0a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s0a0l57;	.
+:c0_0c2s0a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s0n0;
+	logset:endPointOf :linkc0_0c2s0a0l50;
+	logset:endPointOf :linkc0_0c2s0a0l51;	.
+:c0_0c2s0a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s0n1;
+	logset:endPointOf :linkc0_0c2s0a0l52;
+	logset:endPointOf :linkc0_0c2s0a0l53;	.
+:c0_0c2s0a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s0n2;
+	logset:endPointOf :linkc0_0c2s0a0l54;
+	logset:endPointOf :linkc0_0c2s0a0l55;	.
+:c0_0c2s0a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s0n3;
+	logset:endPointOf :linkc0_0c2s0a0l56;
+	logset:endPointOf :linkc0_0c2s0a0l57;	.
+:c0_0c2s0n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s0n0;	.
+:c0_0c2s0n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s0n1;	.
+:c0_0c2s0n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s0n2;	.
+:c0_0c2s0n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s0n3;	.
+:c0_0c2s10a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l00;	.
+:c0_0c2s10a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l07 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l10;	.
+:c0_0c2s10a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l11;	.
+:c0_0c2s10a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l16;	.
+:c0_0c2s10a0l17 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l20 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l21;	.
+:c0_0c2s10a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l22;	.
+:c0_0c2s10a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l23;	.
+:c0_0c2s10a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l24;	.
+:c0_0c2s10a0l25 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l26;	.
+:c0_0c2s10a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l24;	.
+:c0_0c2s10a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l30;	.
+:c0_0c2s10a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l42;	.
+:c0_0c2s10a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l32;	.
+:c0_0c2s10a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l32;	.
+:c0_0c2s10a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l30;	.
+:c0_0c2s10a0l36 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l40;	.
+:c0_0c2s10a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l41;	.
+:c0_0c2s10a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l40;	.
+:c0_0c2s10a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l31;	.
+:c0_0c2s10a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l33;	.
+:c0_0c2s10a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l43;	.
+:c0_0c2s10a0l46 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l47 a craydict:NetworkTile ;	.
+:c0_0c2s10a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l50;	.
+:c0_0c2s10a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l51;	.
+:c0_0c2s10a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l52;	.
+:c0_0c2s10a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l53;	.
+:c0_0c2s10a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l54;	.
+:c0_0c2s10a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l55;	.
+:c0_0c2s10a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l56;	.
+:c0_0c2s10a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s10a0l57;	.
+:c0_0c2s10a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s10n0;
+	logset:endPointOf :linkc0_0c2s10a0l50;
+	logset:endPointOf :linkc0_0c2s10a0l51;	.
+:c0_0c2s10a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s10n1;
+	logset:endPointOf :linkc0_0c2s10a0l52;
+	logset:endPointOf :linkc0_0c2s10a0l53;	.
+:c0_0c2s10a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s10n2;
+	logset:endPointOf :linkc0_0c2s10a0l54;
+	logset:endPointOf :linkc0_0c2s10a0l55;	.
+:c0_0c2s10a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s10n3;
+	logset:endPointOf :linkc0_0c2s10a0l56;
+	logset:endPointOf :linkc0_0c2s10a0l57;	.
+:c0_0c2s10n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s10n0;	.
+:c0_0c2s10n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s10n1;	.
+:c0_0c2s10n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s10n2;	.
+:c0_0c2s10n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s10n3;	.
+:c0_0c2s11a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l00;	.
+:c0_0c2s11a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l07 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l10;	.
+:c0_0c2s11a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l11;	.
+:c0_0c2s11a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l07;	.
+:c0_0c2s11a0l17 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l20 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l21;	.
+:c0_0c2s11a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l22;	.
+:c0_0c2s11a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l23;	.
+:c0_0c2s11a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l24;	.
+:c0_0c2s11a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l17;	.
+:c0_0c2s11a0l26 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l24;	.
+:c0_0c2s11a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l30;	.
+:c0_0c2s11a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l42;	.
+:c0_0c2s11a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l32;	.
+:c0_0c2s11a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l43;	.
+:c0_0c2s11a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l41;	.
+:c0_0c2s11a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l43;	.
+:c0_0c2s11a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l31;	.
+:c0_0c2s11a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l41;	.
+:c0_0c2s11a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l40;	.
+:c0_0c2s11a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l31;	.
+:c0_0c2s11a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l33;	.
+:c0_0c2s11a0l45 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l46 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l47 a craydict:NetworkTile ;	.
+:c0_0c2s11a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l50;	.
+:c0_0c2s11a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l51;	.
+:c0_0c2s11a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l52;	.
+:c0_0c2s11a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l53;	.
+:c0_0c2s11a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l54;	.
+:c0_0c2s11a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l55;	.
+:c0_0c2s11a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l56;	.
+:c0_0c2s11a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s11a0l57;	.
+:c0_0c2s11a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s11n0;
+	logset:endPointOf :linkc0_0c2s11a0l50;
+	logset:endPointOf :linkc0_0c2s11a0l51;	.
+:c0_0c2s11a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s11n1;
+	logset:endPointOf :linkc0_0c2s11a0l52;
+	logset:endPointOf :linkc0_0c2s11a0l53;	.
+:c0_0c2s11a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s11n2;
+	logset:endPointOf :linkc0_0c2s11a0l54;
+	logset:endPointOf :linkc0_0c2s11a0l55;	.
+:c0_0c2s11a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s11n3;
+	logset:endPointOf :linkc0_0c2s11a0l56;
+	logset:endPointOf :linkc0_0c2s11a0l57;	.
+:c0_0c2s11n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s11n0;	.
+:c0_0c2s11n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s11n1;	.
+:c0_0c2s11n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s11n2;	.
+:c0_0c2s11n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s11n3;	.
+:c0_0c2s12a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l00;	.
+:c0_0c2s12a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l26;	.
+:c0_0c2s12a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l10;	.
+:c0_0c2s12a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l11;	.
+:c0_0c2s12a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l16;	.
+:c0_0c2s12a0l17 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l20 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l21;	.
+:c0_0c2s12a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l22;	.
+:c0_0c2s12a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l23;	.
+:c0_0c2s12a0l24 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l27;	.
+:c0_0c2s12a0l26 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l24;	.
+:c0_0c2s12a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l30;	.
+:c0_0c2s12a0l31 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l32 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l32;	.
+:c0_0c2s12a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l31;	.
+:c0_0c2s12a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l42;	.
+:c0_0c2s12a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l31;	.
+:c0_0c2s12a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l41;	.
+:c0_0c2s12a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l40;	.
+:c0_0c2s12a0l42 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l30;	.
+:c0_0c2s12a0l46 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l47 a craydict:NetworkTile ;	.
+:c0_0c2s12a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l50;	.
+:c0_0c2s12a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l51;	.
+:c0_0c2s12a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l52;	.
+:c0_0c2s12a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l53;	.
+:c0_0c2s12a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l54;	.
+:c0_0c2s12a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l55;	.
+:c0_0c2s12a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l56;	.
+:c0_0c2s12a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s12a0l57;	.
+:c0_0c2s12a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s12n0;
+	logset:endPointOf :linkc0_0c2s12a0l50;
+	logset:endPointOf :linkc0_0c2s12a0l51;	.
+:c0_0c2s12a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s12n1;
+	logset:endPointOf :linkc0_0c2s12a0l52;
+	logset:endPointOf :linkc0_0c2s12a0l53;	.
+:c0_0c2s12a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s12n2;
+	logset:endPointOf :linkc0_0c2s12a0l54;
+	logset:endPointOf :linkc0_0c2s12a0l55;	.
+:c0_0c2s12a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s12n3;
+	logset:endPointOf :linkc0_0c2s12a0l56;
+	logset:endPointOf :linkc0_0c2s12a0l57;	.
+:c0_0c2s12n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s12n0;	.
+:c0_0c2s12n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s12n1;	.
+:c0_0c2s12n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s12n2;	.
+:c0_0c2s12n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s12n3;	.
+:c0_0c2s1a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l00;	.
+:c0_0c2s1a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l07;	.
+:c0_0c2s1a0l10 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l11 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l16;	.
+:c0_0c2s1a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l17;	.
+:c0_0c2s1a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l23;	.
+:c0_0c2s1a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l21;	.
+:c0_0c2s1a0l22 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l23;	.
+:c0_0c2s1a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l24;	.
+:c0_0c2s1a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l25;	.
+:c0_0c2s1a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l26;	.
+:c0_0c2s1a0l27 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l30;	.
+:c0_0c2s1a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l31;	.
+:c0_0c2s1a0l32 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l45;	.
+:c0_0c2s1a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l36;	.
+:c0_0c2s1a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l47;	.
+:c0_0c2s1a0l40 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l41;	.
+:c0_0c2s1a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l42;	.
+:c0_0c2s1a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l43;	.
+:c0_0c2s1a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s1a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l35;	.
+:c0_0c2s1a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l46;	.
+:c0_0c2s1a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l37;	.
+:c0_0c2s1a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l50;	.
+:c0_0c2s1a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l51;	.
+:c0_0c2s1a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l52;	.
+:c0_0c2s1a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l53;	.
+:c0_0c2s1a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l54;	.
+:c0_0c2s1a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l55;	.
+:c0_0c2s1a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l56;	.
+:c0_0c2s1a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s1a0l57;	.
+:c0_0c2s1a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s1n0;
+	logset:endPointOf :linkc0_0c2s1a0l50;
+	logset:endPointOf :linkc0_0c2s1a0l51;	.
+:c0_0c2s1a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s1n1;
+	logset:endPointOf :linkc0_0c2s1a0l52;
+	logset:endPointOf :linkc0_0c2s1a0l53;	.
+:c0_0c2s1a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s1n2;
+	logset:endPointOf :linkc0_0c2s1a0l54;
+	logset:endPointOf :linkc0_0c2s1a0l55;	.
+:c0_0c2s1a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s1n3;
+	logset:endPointOf :linkc0_0c2s1a0l56;
+	logset:endPointOf :linkc0_0c2s1a0l57;	.
+:c0_0c2s1n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s1n0;	.
+:c0_0c2s1n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s1n1;	.
+:c0_0c2s1n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s1n2;	.
+:c0_0c2s1n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s1n3;	.
+:c0_0c2s2a0l00 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l07;	.
+:c0_0c2s2a0l10 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l11;	.
+:c0_0c2s2a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l16;	.
+:c0_0c2s2a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l17;	.
+:c0_0c2s2a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l23;	.
+:c0_0c2s2a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l10;	.
+:c0_0c2s2a0l22 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l23;	.
+:c0_0c2s2a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l24;	.
+:c0_0c2s2a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l25;	.
+:c0_0c2s2a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l26;	.
+:c0_0c2s2a0l27 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l30 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l31;	.
+:c0_0c2s2a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l32;	.
+:c0_0c2s2a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l33;	.
+:c0_0c2s2a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l45;	.
+:c0_0c2s2a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l36;	.
+:c0_0c2s2a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l47;	.
+:c0_0c2s2a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l40;	.
+:c0_0c2s2a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l41;	.
+:c0_0c2s2a0l42 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s2a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l35;	.
+:c0_0c2s2a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l46;	.
+:c0_0c2s2a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l37;	.
+:c0_0c2s2a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l50;	.
+:c0_0c2s2a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l51;	.
+:c0_0c2s2a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l52;	.
+:c0_0c2s2a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l53;	.
+:c0_0c2s2a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l54;	.
+:c0_0c2s2a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l55;	.
+:c0_0c2s2a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l56;	.
+:c0_0c2s2a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s2a0l57;	.
+:c0_0c2s2a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s2n0;
+	logset:endPointOf :linkc0_0c2s2a0l50;
+	logset:endPointOf :linkc0_0c2s2a0l51;	.
+:c0_0c2s2a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s2n1;
+	logset:endPointOf :linkc0_0c2s2a0l52;
+	logset:endPointOf :linkc0_0c2s2a0l53;	.
+:c0_0c2s2a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s2n2;
+	logset:endPointOf :linkc0_0c2s2a0l54;
+	logset:endPointOf :linkc0_0c2s2a0l55;	.
+:c0_0c2s2a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s2n3;
+	logset:endPointOf :linkc0_0c2s2a0l56;
+	logset:endPointOf :linkc0_0c2s2a0l57;	.
+:c0_0c2s2n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s2n0;	.
+:c0_0c2s2n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s2n1;	.
+:c0_0c2s2n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s2n2;	.
+:c0_0c2s2n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s2n3;	.
+:c0_0c2s3a0l00 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l07;	.
+:c0_0c2s3a0l10 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l00;	.
+:c0_0c2s3a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l16;	.
+:c0_0c2s3a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l17;	.
+:c0_0c2s3a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l23;	.
+:c0_0c2s3a0l21 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l21;	.
+:c0_0c2s3a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l23;	.
+:c0_0c2s3a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l24;	.
+:c0_0c2s3a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l25;	.
+:c0_0c2s3a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l26;	.
+:c0_0c2s3a0l27 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l30 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l31;	.
+:c0_0c2s3a0l32 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l33;	.
+:c0_0c2s3a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l45;	.
+:c0_0c2s3a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l36;	.
+:c0_0c2s3a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l47;	.
+:c0_0c2s3a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l40;	.
+:c0_0c2s3a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l41;	.
+:c0_0c2s3a0l42 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l43;	.
+:c0_0c2s3a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s3a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l35;	.
+:c0_0c2s3a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l46;	.
+:c0_0c2s3a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l37;	.
+:c0_0c2s3a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l50;	.
+:c0_0c2s3a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l51;	.
+:c0_0c2s3a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l52;	.
+:c0_0c2s3a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l53;	.
+:c0_0c2s3a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l54;	.
+:c0_0c2s3a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l55;	.
+:c0_0c2s3a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l56;	.
+:c0_0c2s3a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s3a0l57;	.
+:c0_0c2s3a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s3n0;
+	logset:endPointOf :linkc0_0c2s3a0l50;
+	logset:endPointOf :linkc0_0c2s3a0l51;	.
+:c0_0c2s3a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s3n1;
+	logset:endPointOf :linkc0_0c2s3a0l52;
+	logset:endPointOf :linkc0_0c2s3a0l53;	.
+:c0_0c2s3a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s3n2;
+	logset:endPointOf :linkc0_0c2s3a0l54;
+	logset:endPointOf :linkc0_0c2s3a0l55;	.
+:c0_0c2s3a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s3n3;
+	logset:endPointOf :linkc0_0c2s3a0l56;
+	logset:endPointOf :linkc0_0c2s3a0l57;	.
+:c0_0c2s3n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s3n0;	.
+:c0_0c2s3n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s3n1;	.
+:c0_0c2s3n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s3n2;	.
+:c0_0c2s3n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s3n3;	.
+:c0_0c2s4a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l21;	.
+:c0_0c2s4a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l07;	.
+:c0_0c2s4a0l10 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l11;	.
+:c0_0c2s4a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l16;	.
+:c0_0c2s4a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l17;	.
+:c0_0c2s4a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l23;	.
+:c0_0c2s4a0l21 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l20;	.
+:c0_0c2s4a0l23 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l24;	.
+:c0_0c2s4a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l25;	.
+:c0_0c2s4a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l26;	.
+:c0_0c2s4a0l27 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l30;	.
+:c0_0c2s4a0l31 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l32;	.
+:c0_0c2s4a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l45;	.
+:c0_0c2s4a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l36;	.
+:c0_0c2s4a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l47;	.
+:c0_0c2s4a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l40;	.
+:c0_0c2s4a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l41;	.
+:c0_0c2s4a0l42 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l43;	.
+:c0_0c2s4a0l44 a craydict:NetworkTile ;	.
+:c0_0c2s4a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l35;	.
+:c0_0c2s4a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l46;	.
+:c0_0c2s4a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l37;	.
+:c0_0c2s4a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l50;	.
+:c0_0c2s4a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l51;	.
+:c0_0c2s4a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l52;	.
+:c0_0c2s4a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l53;	.
+:c0_0c2s4a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l54;	.
+:c0_0c2s4a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l55;	.
+:c0_0c2s4a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l56;	.
+:c0_0c2s4a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s4a0l57;	.
+:c0_0c2s4a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s4n0;
+	logset:endPointOf :linkc0_0c2s4a0l50;
+	logset:endPointOf :linkc0_0c2s4a0l51;	.
+:c0_0c2s4a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s4n1;
+	logset:endPointOf :linkc0_0c2s4a0l52;
+	logset:endPointOf :linkc0_0c2s4a0l53;	.
+:c0_0c2s4a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s4n2;
+	logset:endPointOf :linkc0_0c2s4a0l54;
+	logset:endPointOf :linkc0_0c2s4a0l55;	.
+:c0_0c2s4a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s4n3;
+	logset:endPointOf :linkc0_0c2s4a0l56;
+	logset:endPointOf :linkc0_0c2s4a0l57;	.
+:c0_0c2s4n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s4n0;	.
+:c0_0c2s4n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s4n1;	.
+:c0_0c2s4n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s4n2;	.
+:c0_0c2s4n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s4n3;	.
+:c0_0c2s8a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l00;	.
+:c0_0c2s8a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l07 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l10;	.
+:c0_0c2s8a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l11;	.
+:c0_0c2s8a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l16 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l17;	.
+:c0_0c2s8a0l20 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l21;	.
+:c0_0c2s8a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l22;	.
+:c0_0c2s8a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l23;	.
+:c0_0c2s8a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l24;	.
+:c0_0c2s8a0l25 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l26;	.
+:c0_0c2s8a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l27;	.
+:c0_0c2s8a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l30;	.
+:c0_0c2s8a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l42;	.
+:c0_0c2s8a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l32;	.
+:c0_0c2s8a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l43;	.
+:c0_0c2s8a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l32;	.
+:c0_0c2s8a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l40;	.
+:c0_0c2s8a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l41;	.
+:c0_0c2s8a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l41;	.
+:c0_0c2s8a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l40;	.
+:c0_0c2s8a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l31;	.
+:c0_0c2s8a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l41;	.
+:c0_0c2s8a0l45 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l46 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l47 a craydict:NetworkTile ;	.
+:c0_0c2s8a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l50;	.
+:c0_0c2s8a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l51;	.
+:c0_0c2s8a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l52;	.
+:c0_0c2s8a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l53;	.
+:c0_0c2s8a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l54;	.
+:c0_0c2s8a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l55;	.
+:c0_0c2s8a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l56;	.
+:c0_0c2s8a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s8a0l57;	.
+:c0_0c2s8a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s8n0;
+	logset:endPointOf :linkc0_0c2s8a0l50;
+	logset:endPointOf :linkc0_0c2s8a0l51;	.
+:c0_0c2s8a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s8n1;
+	logset:endPointOf :linkc0_0c2s8a0l52;
+	logset:endPointOf :linkc0_0c2s8a0l53;	.
+:c0_0c2s8a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s8n2;
+	logset:endPointOf :linkc0_0c2s8a0l54;
+	logset:endPointOf :linkc0_0c2s8a0l55;	.
+:c0_0c2s8a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s8n3;
+	logset:endPointOf :linkc0_0c2s8a0l56;
+	logset:endPointOf :linkc0_0c2s8a0l57;	.
+:c0_0c2s8n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s8n0;	.
+:c0_0c2s8n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s8n1;	.
+:c0_0c2s8n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s8n2;	.
+:c0_0c2s8n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s8n3;	.
+:c0_0c2s9a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l00;	.
+:c0_0c2s9a0l01 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l02 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l03 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l04 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l05 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l06 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l07;	.
+:c0_0c2s9a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l10;	.
+:c0_0c2s9a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l11;	.
+:c0_0c2s9a0l12 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l13 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l14 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l15 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l16 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l17 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l20 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l21;	.
+:c0_0c2s9a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l22;	.
+:c0_0c2s9a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l23;	.
+:c0_0c2s9a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l24;	.
+:c0_0c2s9a0l25 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l26;	.
+:c0_0c2s9a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l24;	.
+:c0_0c2s9a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l30;	.
+:c0_0c2s9a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l42;	.
+:c0_0c2s9a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l32;	.
+:c0_0c2s9a0l33 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l34 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l35 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l33;	.
+:c0_0c2s9a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l31;	.
+:c0_0c2s9a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l41;	.
+:c0_0c2s9a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l40;	.
+:c0_0c2s9a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l31;	.
+:c0_0c2s9a0l43 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l40;	.
+:c0_0c2s9a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l30;	.
+:c0_0c2s9a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l41;	.
+:c0_0c2s9a0l47 a craydict:NetworkTile ;	.
+:c0_0c2s9a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l50;	.
+:c0_0c2s9a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l51;	.
+:c0_0c2s9a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l52;	.
+:c0_0c2s9a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l53;	.
+:c0_0c2s9a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l54;	.
+:c0_0c2s9a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l55;	.
+:c0_0c2s9a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l56;	.
+:c0_0c2s9a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc0_0c2s9a0l57;	.
+:c0_0c2s9a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s9n0;
+	logset:endPointOf :linkc0_0c2s9a0l50;
+	logset:endPointOf :linkc0_0c2s9a0l51;	.
+:c0_0c2s9a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s9n1;
+	logset:endPointOf :linkc0_0c2s9a0l52;
+	logset:endPointOf :linkc0_0c2s9a0l53;	.
+:c0_0c2s9a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s9n2;
+	logset:endPointOf :linkc0_0c2s9a0l54;
+	logset:endPointOf :linkc0_0c2s9a0l55;	.
+:c0_0c2s9a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec0_0c2s9n3;
+	logset:endPointOf :linkc0_0c2s9a0l56;
+	logset:endPointOf :linkc0_0c2s9a0l57;	.
+:c0_0c2s9n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s9n0;	.
+:c0_0c2s9n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s9n1;	.
+:c0_0c2s9n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s9n2;	.
+:c0_0c2s9n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec0_0c2s9n3;	.
+:c1_0c0s0a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l00;	.
+:c1_0c0s0a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l16;	.
+:c1_0c0s0a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l10;	.
+:c1_0c0s0a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l11;	.
+:c1_0c0s0a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l07;	.
+:c1_0c0s0a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l17;	.
+:c1_0c0s0a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l20;	.
+:c1_0c0s0a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l21;	.
+:c1_0c0s0a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l22;	.
+:c1_0c0s0a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l23;	.
+:c1_0c0s0a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l07;	.
+:c1_0c0s0a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l17;	.
+:c1_0c0s0a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l16;	.
+:c1_0c0s0a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l44;	.
+:c1_0c0s0a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l30;	.
+:c1_0c0s0a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l31;	.
+:c1_0c0s0a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l32;	.
+:c1_0c0s0a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l33;	.
+:c1_0c0s0a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l34;	.
+:c1_0c0s0a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l37;	.
+:c1_0c0s0a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l40;	.
+:c1_0c0s0a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l41;	.
+:c1_0c0s0a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l42;	.
+:c1_0c0s0a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l43;	.
+:c1_0c0s0a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l27;	.
+:c1_0c0s0a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s0a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l46;	.
+:c1_0c0s0a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l47;	.
+:c1_0c0s0a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l50;	.
+:c1_0c0s0a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l51;	.
+:c1_0c0s0a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l52;	.
+:c1_0c0s0a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l53;	.
+:c1_0c0s0a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l54;	.
+:c1_0c0s0a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l55;	.
+:c1_0c0s0a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l56;	.
+:c1_0c0s0a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s0a0l57;	.
+:c1_0c0s0a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s0n0;
+	logset:endPointOf :linkc1_0c0s0a0l50;
+	logset:endPointOf :linkc1_0c0s0a0l51;	.
+:c1_0c0s0a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s0n1;
+	logset:endPointOf :linkc1_0c0s0a0l52;
+	logset:endPointOf :linkc1_0c0s0a0l53;	.
+:c1_0c0s0a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s0n2;
+	logset:endPointOf :linkc1_0c0s0a0l54;
+	logset:endPointOf :linkc1_0c0s0a0l55;	.
+:c1_0c0s0a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s0n3;
+	logset:endPointOf :linkc1_0c0s0a0l56;
+	logset:endPointOf :linkc1_0c0s0a0l57;	.
+:c1_0c0s0n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s0n0;	.
+:c1_0c0s0n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s0n1;	.
+:c1_0c0s0n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s0n2;	.
+:c1_0c0s0n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s0n3;	.
+:c1_0c0s10a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l00;	.
+:c1_0c0s10a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l07;	.
+:c1_0c0s10a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l11;	.
+:c1_0c0s10a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l10;	.
+:c1_0c0s10a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l16;	.
+:c1_0c0s10a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l17;	.
+:c1_0c0s10a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l20;	.
+:c1_0c0s10a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l00;	.
+:c1_0c0s10a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l10;	.
+:c1_0c0s10a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l11;	.
+:c1_0c0s10a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l24;	.
+:c1_0c0s10a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l25;	.
+:c1_0c0s10a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l26;	.
+:c1_0c0s10a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l24;	.
+:c1_0c0s10a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l30;	.
+:c1_0c0s10a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l43;	.
+:c1_0c0s10a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l32;	.
+:c1_0c0s10a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l30;	.
+:c1_0c0s10a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l31;	.
+:c1_0c0s10a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l40;	.
+:c1_0c0s10a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l40;	.
+:c1_0c0s10a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l41;	.
+:c1_0c0s10a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s10a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l33;	.
+:c1_0c0s10a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l33;	.
+:c1_0c0s10a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l43;	.
+:c1_0c0s10a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l41;	.
+:c1_0c0s10a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l41;	.
+:c1_0c0s10a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l50;	.
+:c1_0c0s10a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l51;	.
+:c1_0c0s10a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l52;	.
+:c1_0c0s10a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l53;	.
+:c1_0c0s10a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l54;	.
+:c1_0c0s10a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l55;	.
+:c1_0c0s10a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l56;	.
+:c1_0c0s10a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s10a0l57;	.
+:c1_0c0s10a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s10n0;
+	logset:endPointOf :linkc1_0c0s10a0l50;
+	logset:endPointOf :linkc1_0c0s10a0l51;	.
+:c1_0c0s10a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s10n1;
+	logset:endPointOf :linkc1_0c0s10a0l52;
+	logset:endPointOf :linkc1_0c0s10a0l53;	.
+:c1_0c0s10a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s10n2;
+	logset:endPointOf :linkc1_0c0s10a0l54;
+	logset:endPointOf :linkc1_0c0s10a0l55;	.
+:c1_0c0s10a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s10n3;
+	logset:endPointOf :linkc1_0c0s10a0l56;
+	logset:endPointOf :linkc1_0c0s10a0l57;	.
+:c1_0c0s10n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s10n0;	.
+:c1_0c0s10n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s10n1;	.
+:c1_0c0s10n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s10n2;	.
+:c1_0c0s10n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s10n3;	.
+:c1_0c0s11a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l00;	.
+:c1_0c0s11a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l07;	.
+:c1_0c0s11a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l11;	.
+:c1_0c0s11a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l10;	.
+:c1_0c0s11a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l07;	.
+:c1_0c0s11a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l17;	.
+:c1_0c0s11a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l20;	.
+:c1_0c0s11a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l00;	.
+:c1_0c0s11a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l10;	.
+:c1_0c0s11a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l11;	.
+:c1_0c0s11a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l24;	.
+:c1_0c0s11a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l17;	.
+:c1_0c0s11a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l26;	.
+:c1_0c0s11a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l24;	.
+:c1_0c0s11a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l30;	.
+:c1_0c0s11a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l43;	.
+:c1_0c0s11a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l43;	.
+:c1_0c0s11a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l41;	.
+:c1_0c0s11a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l43;	.
+:c1_0c0s11a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l31;	.
+:c1_0c0s11a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l40;	.
+:c1_0c0s11a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l41;	.
+:c1_0c0s11a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s11a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l33;	.
+:c1_0c0s11a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l33;	.
+:c1_0c0s11a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l30;	.
+:c1_0c0s11a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l42;	.
+:c1_0c0s11a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l42;	.
+:c1_0c0s11a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l50;	.
+:c1_0c0s11a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l51;	.
+:c1_0c0s11a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l52;	.
+:c1_0c0s11a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l53;	.
+:c1_0c0s11a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l54;	.
+:c1_0c0s11a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l55;	.
+:c1_0c0s11a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l56;	.
+:c1_0c0s11a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s11a0l57;	.
+:c1_0c0s11a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s11n0;
+	logset:endPointOf :linkc1_0c0s11a0l50;
+	logset:endPointOf :linkc1_0c0s11a0l51;	.
+:c1_0c0s11a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s11n1;
+	logset:endPointOf :linkc1_0c0s11a0l52;
+	logset:endPointOf :linkc1_0c0s11a0l53;	.
+:c1_0c0s11a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s11n2;
+	logset:endPointOf :linkc1_0c0s11a0l54;
+	logset:endPointOf :linkc1_0c0s11a0l55;	.
+:c1_0c0s11a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s11n3;
+	logset:endPointOf :linkc1_0c0s11a0l56;
+	logset:endPointOf :linkc1_0c0s11a0l57;	.
+:c1_0c0s11n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s11n0;	.
+:c1_0c0s11n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s11n1;	.
+:c1_0c0s11n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s11n2;	.
+:c1_0c0s11n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s11n3;	.
+:c1_0c0s12a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l00;	.
+:c1_0c0s12a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l26;	.
+:c1_0c0s12a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l11;	.
+:c1_0c0s12a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l10;	.
+:c1_0c0s12a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l16;	.
+:c1_0c0s12a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l17;	.
+:c1_0c0s12a0l20 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l00;	.
+:c1_0c0s12a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l10;	.
+:c1_0c0s12a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l11;	.
+:c1_0c0s12a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l24;	.
+:c1_0c0s12a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l27;	.
+:c1_0c0s12a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l26;	.
+:c1_0c0s12a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l24;	.
+:c1_0c0s12a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l30;	.
+:c1_0c0s12a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l33 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l32;	.
+:c1_0c0s12a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l31;	.
+:c1_0c0s12a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l42;	.
+:c1_0c0s12a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l31;	.
+:c1_0c0s12a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l40;	.
+:c1_0c0s12a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l41;	.
+:c1_0c0s12a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l43 a craydict:NetworkTile ;	.
+:c1_0c0s12a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l33;	.
+:c1_0c0s12a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l30;	.
+:c1_0c0s12a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l32;	.
+:c1_0c0s12a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l40;	.
+:c1_0c0s12a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l50;	.
+:c1_0c0s12a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l51;	.
+:c1_0c0s12a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l52;	.
+:c1_0c0s12a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l53;	.
+:c1_0c0s12a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l54;	.
+:c1_0c0s12a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l55;	.
+:c1_0c0s12a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l56;	.
+:c1_0c0s12a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s12a0l57;	.
+:c1_0c0s12a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s12n0;
+	logset:endPointOf :linkc1_0c0s12a0l50;
+	logset:endPointOf :linkc1_0c0s12a0l51;	.
+:c1_0c0s12a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s12n1;
+	logset:endPointOf :linkc1_0c0s12a0l52;
+	logset:endPointOf :linkc1_0c0s12a0l53;	.
+:c1_0c0s12a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s12n2;
+	logset:endPointOf :linkc1_0c0s12a0l54;
+	logset:endPointOf :linkc1_0c0s12a0l55;	.
+:c1_0c0s12a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s12n3;
+	logset:endPointOf :linkc1_0c0s12a0l56;
+	logset:endPointOf :linkc1_0c0s12a0l57;	.
+:c1_0c0s12n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s12n0;	.
+:c1_0c0s12n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s12n1;	.
+:c1_0c0s12n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s12n2;	.
+:c1_0c0s12n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s12n3;	.
+:c1_0c0s13a0l00 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l16;	.
+:c1_0c0s13a0l10 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l11 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l07;	.
+:c1_0c0s13a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l25;	.
+:c1_0c0s13a0l20 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l00;	.
+:c1_0c0s13a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l10;	.
+:c1_0c0s13a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l11;	.
+:c1_0c0s13a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l24;	.
+:c1_0c0s13a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l25;	.
+:c1_0c0s13a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l25;	.
+:c1_0c0s13a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l24;	.
+:c1_0c0s13a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l30;	.
+:c1_0c0s13a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l33 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l32;	.
+:c1_0c0s13a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l42;	.
+:c1_0c0s13a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l43;	.
+:c1_0c0s13a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l40;	.
+:c1_0c0s13a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l40;	.
+:c1_0c0s13a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l41;	.
+:c1_0c0s13a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l43 a craydict:NetworkTile ;	.
+:c1_0c0s13a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l33;	.
+:c1_0c0s13a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l30;	.
+:c1_0c0s13a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l33;	.
+:c1_0c0s13a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l33;	.
+:c1_0c0s13a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l50;	.
+:c1_0c0s13a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l51;	.
+:c1_0c0s13a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l52;	.
+:c1_0c0s13a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l53;	.
+:c1_0c0s13a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l54;	.
+:c1_0c0s13a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l55;	.
+:c1_0c0s13a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l56;	.
+:c1_0c0s13a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s13a0l57;	.
+:c1_0c0s13a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s13n0;
+	logset:endPointOf :linkc1_0c0s13a0l50;
+	logset:endPointOf :linkc1_0c0s13a0l51;	.
+:c1_0c0s13a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s13n1;
+	logset:endPointOf :linkc1_0c0s13a0l52;
+	logset:endPointOf :linkc1_0c0s13a0l53;	.
+:c1_0c0s13a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s13n2;
+	logset:endPointOf :linkc1_0c0s13a0l54;
+	logset:endPointOf :linkc1_0c0s13a0l55;	.
+:c1_0c0s13a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s13n3;
+	logset:endPointOf :linkc1_0c0s13a0l56;
+	logset:endPointOf :linkc1_0c0s13a0l57;	.
+:c1_0c0s13n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s13n0;	.
+:c1_0c0s13n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s13n1;	.
+:c1_0c0s13n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s13n2;	.
+:c1_0c0s13n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s13n3;	.
+:c1_0c0s14a0l00 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l17;	.
+:c1_0c0s14a0l10 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l11 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l07;	.
+:c1_0c0s14a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l07;	.
+:c1_0c0s14a0l20 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l00;	.
+:c1_0c0s14a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l10;	.
+:c1_0c0s14a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s14a0l11;	.
+:c1_0c0s14a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s14a0l24;	.
+:c1_0c0s14a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l17;	.
+:c1_0c0s14a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l17;	.
+:c1_0c0s14a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l24;	.
+:c1_0c0s14a0l30 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l33 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l43;	.
+:c1_0c0s14a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l42;	.
+:c1_0c0s14a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l43;	.
+:c1_0c0s14a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l32;	.
+:c1_0c0s14a0l40 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l41 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l43 a craydict:NetworkTile ;	.
+:c1_0c0s14a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l33;	.
+:c1_0c0s14a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l31;	.
+:c1_0c0s14a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l41;	.
+:c1_0c0s14a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l31;	.
+:c1_0c0s14a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l50;	.
+:c1_0c0s14a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l51;	.
+:c1_0c0s14a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l52;	.
+:c1_0c0s14a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l53;	.
+:c1_0c0s14a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l54;	.
+:c1_0c0s14a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l55;	.
+:c1_0c0s14a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l56;	.
+:c1_0c0s14a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s14a0l57;	.
+:c1_0c0s14a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s14n0;
+	logset:endPointOf :linkc1_0c0s14a0l50;
+	logset:endPointOf :linkc1_0c0s14a0l51;	.
+:c1_0c0s14a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s14n1;
+	logset:endPointOf :linkc1_0c0s14a0l52;
+	logset:endPointOf :linkc1_0c0s14a0l53;	.
+:c1_0c0s14a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s14n2;
+	logset:endPointOf :linkc1_0c0s14a0l54;
+	logset:endPointOf :linkc1_0c0s14a0l55;	.
+:c1_0c0s14a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s14n3;
+	logset:endPointOf :linkc1_0c0s14a0l56;
+	logset:endPointOf :linkc1_0c0s14a0l57;	.
+:c1_0c0s14n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s14n0;	.
+:c1_0c0s14n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s14n1;	.
+:c1_0c0s14n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s14n2;	.
+:c1_0c0s14n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s14n3;	.
+:c1_0c0s15a0l00 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l16;	.
+:c1_0c0s15a0l10 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l11 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l25;	.
+:c1_0c0s15a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l26;	.
+:c1_0c0s15a0l20 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l00;	.
+:c1_0c0s15a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l10;	.
+:c1_0c0s15a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s15a0l11;	.
+:c1_0c0s15a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l25;	.
+:c1_0c0s15a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l26;	.
+:c1_0c0s15a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l17;	.
+:c1_0c0s15a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s14a0l24;	.
+:c1_0c0s15a0l30 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l33 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l30;	.
+:c1_0c0s15a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l42;	.
+:c1_0c0s15a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l31;	.
+:c1_0c0s15a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l42;	.
+:c1_0c0s15a0l40 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l41 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l43 a craydict:NetworkTile ;	.
+:c1_0c0s15a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l32;	.
+:c1_0c0s15a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l30;	.
+:c1_0c0s15a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l42;	.
+:c1_0c0s15a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l40;	.
+:c1_0c0s15a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l50;	.
+:c1_0c0s15a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l51;	.
+:c1_0c0s15a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l52;	.
+:c1_0c0s15a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l53;	.
+:c1_0c0s15a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l54;	.
+:c1_0c0s15a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l55;	.
+:c1_0c0s15a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l56;	.
+:c1_0c0s15a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s15a0l57;	.
+:c1_0c0s15a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s15n0;
+	logset:endPointOf :linkc1_0c0s15a0l50;
+	logset:endPointOf :linkc1_0c0s15a0l51;	.
+:c1_0c0s15a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s15n1;
+	logset:endPointOf :linkc1_0c0s15a0l52;
+	logset:endPointOf :linkc1_0c0s15a0l53;	.
+:c1_0c0s15a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s15n2;
+	logset:endPointOf :linkc1_0c0s15a0l54;
+	logset:endPointOf :linkc1_0c0s15a0l55;	.
+:c1_0c0s15a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s15n3;
+	logset:endPointOf :linkc1_0c0s15a0l56;
+	logset:endPointOf :linkc1_0c0s15a0l57;	.
+:c1_0c0s15n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s15n0;	.
+:c1_0c0s15n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s15n1;	.
+:c1_0c0s15n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s15n2;	.
+:c1_0c0s15n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s15n3;	.
+:c1_0c0s1a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l00;	.
+:c1_0c0s1a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l16;	.
+:c1_0c0s1a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l10;	.
+:c1_0c0s1a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l11;	.
+:c1_0c0s1a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l07;	.
+:c1_0c0s1a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l17;	.
+:c1_0c0s1a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l23;	.
+:c1_0c0s1a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l21;	.
+:c1_0c0s1a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l22;	.
+:c1_0c0s1a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l23;	.
+:c1_0c0s1a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l07;	.
+:c1_0c0s1a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l17;	.
+:c1_0c0s1a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l16;	.
+:c1_0c0s1a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l44;	.
+:c1_0c0s1a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l30;	.
+:c1_0c0s1a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l31;	.
+:c1_0c0s1a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l32;	.
+:c1_0c0s1a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l33;	.
+:c1_0c0s1a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l34;	.
+:c1_0c0s1a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l37;	.
+:c1_0c0s1a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l40;	.
+:c1_0c0s1a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l41;	.
+:c1_0c0s1a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l42;	.
+:c1_0c0s1a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l43;	.
+:c1_0c0s1a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l27;	.
+:c1_0c0s1a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s1a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l46;	.
+:c1_0c0s1a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l47;	.
+:c1_0c0s1a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l50;	.
+:c1_0c0s1a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l51;	.
+:c1_0c0s1a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l52;	.
+:c1_0c0s1a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l53;	.
+:c1_0c0s1a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l54;	.
+:c1_0c0s1a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l55;	.
+:c1_0c0s1a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l56;	.
+:c1_0c0s1a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s1a0l57;	.
+:c1_0c0s1a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s1n0;
+	logset:endPointOf :linkc1_0c0s1a0l50;
+	logset:endPointOf :linkc1_0c0s1a0l51;	.
+:c1_0c0s1a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s1n1;
+	logset:endPointOf :linkc1_0c0s1a0l52;
+	logset:endPointOf :linkc1_0c0s1a0l53;	.
+:c1_0c0s1a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s1n2;
+	logset:endPointOf :linkc1_0c0s1a0l54;
+	logset:endPointOf :linkc1_0c0s1a0l55;	.
+:c1_0c0s1a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s1n3;
+	logset:endPointOf :linkc1_0c0s1a0l56;
+	logset:endPointOf :linkc1_0c0s1a0l57;	.
+:c1_0c0s1n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s1n0;	.
+:c1_0c0s1n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s1n1;	.
+:c1_0c0s1n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s1n2;	.
+:c1_0c0s1n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s1n3;	.
+:c1_0c0s2a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l00;	.
+:c1_0c0s2a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l16;	.
+:c1_0c0s2a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l10;	.
+:c1_0c0s2a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l11;	.
+:c1_0c0s2a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l07;	.
+:c1_0c0s2a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l17;	.
+:c1_0c0s2a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l23;	.
+:c1_0c0s2a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l10;	.
+:c1_0c0s2a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l22;	.
+:c1_0c0s2a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l23;	.
+:c1_0c0s2a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l07;	.
+:c1_0c0s2a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l17;	.
+:c1_0c0s2a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l16;	.
+:c1_0c0s2a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l44;	.
+:c1_0c0s2a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l30;	.
+:c1_0c0s2a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l31;	.
+:c1_0c0s2a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l32;	.
+:c1_0c0s2a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l33;	.
+:c1_0c0s2a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l34;	.
+:c1_0c0s2a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l37;	.
+:c1_0c0s2a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l40;	.
+:c1_0c0s2a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l41;	.
+:c1_0c0s2a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l42;	.
+:c1_0c0s2a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l43;	.
+:c1_0c0s2a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l27;	.
+:c1_0c0s2a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s2a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l46;	.
+:c1_0c0s2a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l47;	.
+:c1_0c0s2a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l50;	.
+:c1_0c0s2a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l51;	.
+:c1_0c0s2a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l52;	.
+:c1_0c0s2a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l53;	.
+:c1_0c0s2a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l54;	.
+:c1_0c0s2a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l55;	.
+:c1_0c0s2a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l56;	.
+:c1_0c0s2a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s2a0l57;	.
+:c1_0c0s2a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s2n0;
+	logset:endPointOf :linkc1_0c0s2a0l50;
+	logset:endPointOf :linkc1_0c0s2a0l51;	.
+:c1_0c0s2a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s2n1;
+	logset:endPointOf :linkc1_0c0s2a0l52;
+	logset:endPointOf :linkc1_0c0s2a0l53;	.
+:c1_0c0s2a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s2n2;
+	logset:endPointOf :linkc1_0c0s2a0l54;
+	logset:endPointOf :linkc1_0c0s2a0l55;	.
+:c1_0c0s2a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s2n3;
+	logset:endPointOf :linkc1_0c0s2a0l56;
+	logset:endPointOf :linkc1_0c0s2a0l57;	.
+:c1_0c0s2n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s2n0;	.
+:c1_0c0s2n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s2n1;	.
+:c1_0c0s2n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s2n2;	.
+:c1_0c0s2n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s2n3;	.
+:c1_0c0s3a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l00;	.
+:c1_0c0s3a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l16;	.
+:c1_0c0s3a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l10;	.
+:c1_0c0s3a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l00;	.
+:c1_0c0s3a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l07;	.
+:c1_0c0s3a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l17;	.
+:c1_0c0s3a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l23;	.
+:c1_0c0s3a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l21;	.
+:c1_0c0s3a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l21;	.
+:c1_0c0s3a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l23;	.
+:c1_0c0s3a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l07;	.
+:c1_0c0s3a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l17;	.
+:c1_0c0s3a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l16;	.
+:c1_0c0s3a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l44;	.
+:c1_0c0s3a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l30;	.
+:c1_0c0s3a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l31;	.
+:c1_0c0s3a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l32;	.
+:c1_0c0s3a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l33;	.
+:c1_0c0s3a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l34;	.
+:c1_0c0s3a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l37;	.
+:c1_0c0s3a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l40;	.
+:c1_0c0s3a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l41;	.
+:c1_0c0s3a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l42;	.
+:c1_0c0s3a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l43;	.
+:c1_0c0s3a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l27;	.
+:c1_0c0s3a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s3a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l46;	.
+:c1_0c0s3a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l47;	.
+:c1_0c0s3a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l50;	.
+:c1_0c0s3a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l51;	.
+:c1_0c0s3a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l52;	.
+:c1_0c0s3a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l53;	.
+:c1_0c0s3a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l54;	.
+:c1_0c0s3a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l55;	.
+:c1_0c0s3a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l56;	.
+:c1_0c0s3a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s3a0l57;	.
+:c1_0c0s3a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s3n0;
+	logset:endPointOf :linkc1_0c0s3a0l50;
+	logset:endPointOf :linkc1_0c0s3a0l51;	.
+:c1_0c0s3a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s3n1;
+	logset:endPointOf :linkc1_0c0s3a0l52;
+	logset:endPointOf :linkc1_0c0s3a0l53;	.
+:c1_0c0s3a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s3n2;
+	logset:endPointOf :linkc1_0c0s3a0l54;
+	logset:endPointOf :linkc1_0c0s3a0l55;	.
+:c1_0c0s3a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s3n3;
+	logset:endPointOf :linkc1_0c0s3a0l56;
+	logset:endPointOf :linkc1_0c0s3a0l57;	.
+:c1_0c0s3n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s3n0;	.
+:c1_0c0s3n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s3n1;	.
+:c1_0c0s3n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s3n2;	.
+:c1_0c0s3n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s3n3;	.
+:c1_0c0s4a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l21;	.
+:c1_0c0s4a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l16;	.
+:c1_0c0s4a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l10;	.
+:c1_0c0s4a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l11;	.
+:c1_0c0s4a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l07;	.
+:c1_0c0s4a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l17;	.
+:c1_0c0s4a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l23;	.
+:c1_0c0s4a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l21;	.
+:c1_0c0s4a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l20;	.
+:c1_0c0s4a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l23;	.
+:c1_0c0s4a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l07;	.
+:c1_0c0s4a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l17;	.
+:c1_0c0s4a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l16;	.
+:c1_0c0s4a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l44;	.
+:c1_0c0s4a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l30;	.
+:c1_0c0s4a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l31;	.
+:c1_0c0s4a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l32;	.
+:c1_0c0s4a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l33;	.
+:c1_0c0s4a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l34;	.
+:c1_0c0s4a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l37;	.
+:c1_0c0s4a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l40;	.
+:c1_0c0s4a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l41;	.
+:c1_0c0s4a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l42;	.
+:c1_0c0s4a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l43;	.
+:c1_0c0s4a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l27;	.
+:c1_0c0s4a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s4a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l46;	.
+:c1_0c0s4a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l47;	.
+:c1_0c0s4a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l50;	.
+:c1_0c0s4a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l51;	.
+:c1_0c0s4a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l52;	.
+:c1_0c0s4a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l53;	.
+:c1_0c0s4a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l54;	.
+:c1_0c0s4a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l55;	.
+:c1_0c0s4a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l56;	.
+:c1_0c0s4a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s4a0l57;	.
+:c1_0c0s4a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s4n0;
+	logset:endPointOf :linkc1_0c0s4a0l50;
+	logset:endPointOf :linkc1_0c0s4a0l51;	.
+:c1_0c0s4a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s4n1;
+	logset:endPointOf :linkc1_0c0s4a0l52;
+	logset:endPointOf :linkc1_0c0s4a0l53;	.
+:c1_0c0s4a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s4n2;
+	logset:endPointOf :linkc1_0c0s4a0l54;
+	logset:endPointOf :linkc1_0c0s4a0l55;	.
+:c1_0c0s4a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s4n3;
+	logset:endPointOf :linkc1_0c0s4a0l56;
+	logset:endPointOf :linkc1_0c0s4a0l57;	.
+:c1_0c0s4n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s4n0;	.
+:c1_0c0s4n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s4n1;	.
+:c1_0c0s4n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s4n2;	.
+:c1_0c0s4n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s4n3;	.
+:c1_0c0s5a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l11;	.
+:c1_0c0s5a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l07 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l22;	.
+:c1_0c0s5a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l00;	.
+:c1_0c0s5a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l16 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l17 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l23;	.
+:c1_0c0s5a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l22;	.
+:c1_0c0s5a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l22;	.
+:c1_0c0s5a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l23;	.
+:c1_0c0s5a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l07;	.
+:c1_0c0s5a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l17;	.
+:c1_0c0s5a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l16;	.
+:c1_0c0s5a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l44;	.
+:c1_0c0s5a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l30;	.
+:c1_0c0s5a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l31;	.
+:c1_0c0s5a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l32;	.
+:c1_0c0s5a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l33;	.
+:c1_0c0s5a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l34;	.
+:c1_0c0s5a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l37;	.
+:c1_0c0s5a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l40;	.
+:c1_0c0s5a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l41;	.
+:c1_0c0s5a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l42;	.
+:c1_0c0s5a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l43;	.
+:c1_0c0s5a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l27;	.
+:c1_0c0s5a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s5a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l46;	.
+:c1_0c0s5a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l47;	.
+:c1_0c0s5a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l50;	.
+:c1_0c0s5a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l51;	.
+:c1_0c0s5a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l52;	.
+:c1_0c0s5a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l53;	.
+:c1_0c0s5a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l54;	.
+:c1_0c0s5a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l55;	.
+:c1_0c0s5a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l56;	.
+:c1_0c0s5a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s5a0l57;	.
+:c1_0c0s5a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s5n0;
+	logset:endPointOf :linkc1_0c0s5a0l50;
+	logset:endPointOf :linkc1_0c0s5a0l51;	.
+:c1_0c0s5a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s5n1;
+	logset:endPointOf :linkc1_0c0s5a0l52;
+	logset:endPointOf :linkc1_0c0s5a0l53;	.
+:c1_0c0s5a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s5n2;
+	logset:endPointOf :linkc1_0c0s5a0l54;
+	logset:endPointOf :linkc1_0c0s5a0l55;	.
+:c1_0c0s5a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s5n3;
+	logset:endPointOf :linkc1_0c0s5a0l56;
+	logset:endPointOf :linkc1_0c0s5a0l57;	.
+:c1_0c0s5n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s5n0;	.
+:c1_0c0s5n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s5n1;	.
+:c1_0c0s5n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s5n2;	.
+:c1_0c0s5n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s5n3;	.
+:c1_0c0s6a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l10;	.
+:c1_0c0s6a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l07 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l00;	.
+:c1_0c0s6a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l00;	.
+:c1_0c0s6a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l16 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l17 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l23;	.
+:c1_0c0s6a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l10;	.
+:c1_0c0s6a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l10;	.
+:c1_0c0s6a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l23;	.
+:c1_0c0s6a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l07;	.
+:c1_0c0s6a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l17;	.
+:c1_0c0s6a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l16;	.
+:c1_0c0s6a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l44;	.
+:c1_0c0s6a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l30;	.
+:c1_0c0s6a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l31;	.
+:c1_0c0s6a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l32;	.
+:c1_0c0s6a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l33;	.
+:c1_0c0s6a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l34;	.
+:c1_0c0s6a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l37;	.
+:c1_0c0s6a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l40;	.
+:c1_0c0s6a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l41;	.
+:c1_0c0s6a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l42;	.
+:c1_0c0s6a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l43;	.
+:c1_0c0s6a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l27;	.
+:c1_0c0s6a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s6a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l46;	.
+:c1_0c0s6a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l47;	.
+:c1_0c0s6a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l50;	.
+:c1_0c0s6a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l51;	.
+:c1_0c0s6a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l52;	.
+:c1_0c0s6a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l53;	.
+:c1_0c0s6a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l54;	.
+:c1_0c0s6a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l55;	.
+:c1_0c0s6a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l56;	.
+:c1_0c0s6a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s6a0l57;	.
+:c1_0c0s6a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s6n0;
+	logset:endPointOf :linkc1_0c0s6a0l50;
+	logset:endPointOf :linkc1_0c0s6a0l51;	.
+:c1_0c0s6a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s6n1;
+	logset:endPointOf :linkc1_0c0s6a0l52;
+	logset:endPointOf :linkc1_0c0s6a0l53;	.
+:c1_0c0s6a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s6n2;
+	logset:endPointOf :linkc1_0c0s6a0l54;
+	logset:endPointOf :linkc1_0c0s6a0l55;	.
+:c1_0c0s6a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s6n3;
+	logset:endPointOf :linkc1_0c0s6a0l56;
+	logset:endPointOf :linkc1_0c0s6a0l57;	.
+:c1_0c0s6n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s6n0;	.
+:c1_0c0s6n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s6n1;	.
+:c1_0c0s6n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s6n2;	.
+:c1_0c0s6n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s6n3;	.
+:c1_0c0s7a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l11;	.
+:c1_0c0s7a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l07 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l21;	.
+:c1_0c0s7a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l22;	.
+:c1_0c0s7a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l16 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l17 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l23;	.
+:c1_0c0s7a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l10;	.
+:c1_0c0s7a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l21;	.
+:c1_0c0s7a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l22;	.
+:c1_0c0s7a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l07;	.
+:c1_0c0s7a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l17;	.
+:c1_0c0s7a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l16;	.
+:c1_0c0s7a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l44;	.
+:c1_0c0s7a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l30;	.
+:c1_0c0s7a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l31;	.
+:c1_0c0s7a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l32;	.
+:c1_0c0s7a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l33;	.
+:c1_0c0s7a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l34;	.
+:c1_0c0s7a0l35 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l36 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l37;	.
+:c1_0c0s7a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l40;	.
+:c1_0c0s7a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l41;	.
+:c1_0c0s7a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l42;	.
+:c1_0c0s7a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l43;	.
+:c1_0c0s7a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l27;	.
+:c1_0c0s7a0l45 a craydict:NetworkTile ;	.
+:c1_0c0s7a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l46;	.
+:c1_0c0s7a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l47;	.
+:c1_0c0s7a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l50;	.
+:c1_0c0s7a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l51;	.
+:c1_0c0s7a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l52;	.
+:c1_0c0s7a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l53;	.
+:c1_0c0s7a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l54;	.
+:c1_0c0s7a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l55;	.
+:c1_0c0s7a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l56;	.
+:c1_0c0s7a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s7a0l57;	.
+:c1_0c0s7a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s7n0;
+	logset:endPointOf :linkc1_0c0s7a0l50;
+	logset:endPointOf :linkc1_0c0s7a0l51;	.
+:c1_0c0s7a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s7n1;
+	logset:endPointOf :linkc1_0c0s7a0l52;
+	logset:endPointOf :linkc1_0c0s7a0l53;	.
+:c1_0c0s7a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s7n2;
+	logset:endPointOf :linkc1_0c0s7a0l54;
+	logset:endPointOf :linkc1_0c0s7a0l55;	.
+:c1_0c0s7a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s7n3;
+	logset:endPointOf :linkc1_0c0s7a0l56;
+	logset:endPointOf :linkc1_0c0s7a0l57;	.
+:c1_0c0s7n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s7n0;	.
+:c1_0c0s7n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s7n1;	.
+:c1_0c0s7n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s7n2;	.
+:c1_0c0s7n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s7n3;	.
+:c1_0c0s8a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l00;	.
+:c1_0c0s8a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l07;	.
+:c1_0c0s8a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l11;	.
+:c1_0c0s8a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l10;	.
+:c1_0c0s8a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l16;	.
+:c1_0c0s8a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l17;	.
+:c1_0c0s8a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l20;	.
+:c1_0c0s8a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l00;	.
+:c1_0c0s8a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l10;	.
+:c1_0c0s8a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l11;	.
+:c1_0c0s8a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l24;	.
+:c1_0c0s8a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l25;	.
+:c1_0c0s8a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l26;	.
+:c1_0c0s8a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l27;	.
+:c1_0c0s8a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l30;	.
+:c1_0c0s8a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l43;	.
+:c1_0c0s8a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l43;	.
+:c1_0c0s8a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l32;	.
+:c1_0c0s8a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l40;	.
+:c1_0c0s8a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l41;	.
+:c1_0c0s8a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l40;	.
+:c1_0c0s8a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l41;	.
+:c1_0c0s8a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s8a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l33;	.
+:c1_0c0s8a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l41;	.
+:c1_0c0s8a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l30;	.
+:c1_0c0s8a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l41;	.
+:c1_0c0s8a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l40;	.
+:c1_0c0s8a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l50;	.
+:c1_0c0s8a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l51;	.
+:c1_0c0s8a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l52;	.
+:c1_0c0s8a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l53;	.
+:c1_0c0s8a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l54;	.
+:c1_0c0s8a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l55;	.
+:c1_0c0s8a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l56;	.
+:c1_0c0s8a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s8a0l57;	.
+:c1_0c0s8a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s8n0;
+	logset:endPointOf :linkc1_0c0s8a0l50;
+	logset:endPointOf :linkc1_0c0s8a0l51;	.
+:c1_0c0s8a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s8n1;
+	logset:endPointOf :linkc1_0c0s8a0l52;
+	logset:endPointOf :linkc1_0c0s8a0l53;	.
+:c1_0c0s8a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s8n2;
+	logset:endPointOf :linkc1_0c0s8a0l54;
+	logset:endPointOf :linkc1_0c0s8a0l55;	.
+:c1_0c0s8a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s8n3;
+	logset:endPointOf :linkc1_0c0s8a0l56;
+	logset:endPointOf :linkc1_0c0s8a0l57;	.
+:c1_0c0s8n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s8n0;	.
+:c1_0c0s8n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s8n1;	.
+:c1_0c0s8n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s8n2;	.
+:c1_0c0s8n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s8n3;	.
+:c1_0c0s9a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l00;	.
+:c1_0c0s9a0l01 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l02 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l03 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l04 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l05 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l06 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l07;	.
+:c1_0c0s9a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l11;	.
+:c1_0c0s9a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l10;	.
+:c1_0c0s9a0l12 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l13 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l14 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l15 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l16;	.
+:c1_0c0s9a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l17;	.
+:c1_0c0s9a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l20;	.
+:c1_0c0s9a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l00;	.
+:c1_0c0s9a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l10;	.
+:c1_0c0s9a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l11;	.
+:c1_0c0s9a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l24;	.
+:c1_0c0s9a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l25;	.
+:c1_0c0s9a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l26;	.
+:c1_0c0s9a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l24;	.
+:c1_0c0s9a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l30;	.
+:c1_0c0s9a0l31 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l32 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l43;	.
+:c1_0c0s9a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l43;	.
+:c1_0c0s9a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l32;	.
+:c1_0c0s9a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l33;	.
+:c1_0c0s9a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l31;	.
+:c1_0c0s9a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l40;	.
+:c1_0c0s9a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l41;	.
+:c1_0c0s9a0l42 a craydict:NetworkTile ;	.
+:c1_0c0s9a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l33;	.
+:c1_0c0s9a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l40;	.
+:c1_0c0s9a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l30;	.
+:c1_0c0s9a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l41;	.
+:c1_0c0s9a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l40;	.
+:c1_0c0s9a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l50;	.
+:c1_0c0s9a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l51;	.
+:c1_0c0s9a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l52;	.
+:c1_0c0s9a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l53;	.
+:c1_0c0s9a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l54;	.
+:c1_0c0s9a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l55;	.
+:c1_0c0s9a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l56;	.
+:c1_0c0s9a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c0s9a0l57;	.
+:c1_0c0s9a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s9n0;
+	logset:endPointOf :linkc1_0c0s9a0l50;
+	logset:endPointOf :linkc1_0c0s9a0l51;	.
+:c1_0c0s9a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s9n1;
+	logset:endPointOf :linkc1_0c0s9a0l52;
+	logset:endPointOf :linkc1_0c0s9a0l53;	.
+:c1_0c0s9a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s9n2;
+	logset:endPointOf :linkc1_0c0s9a0l54;
+	logset:endPointOf :linkc1_0c0s9a0l55;	.
+:c1_0c0s9a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c0s9n3;
+	logset:endPointOf :linkc1_0c0s9a0l56;
+	logset:endPointOf :linkc1_0c0s9a0l57;	.
+:c1_0c0s9n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s9n0;	.
+:c1_0c0s9n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s9n1;	.
+:c1_0c0s9n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s9n2;	.
+:c1_0c0s9n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c0s9n3;	.
+:c1_0c1s0a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l00;	.
+:c1_0c1s0a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l24;	.
+:c1_0c1s0a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l10;	.
+:c1_0c1s0a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l11;	.
+:c1_0c1s0a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l26;	.
+:c1_0c1s0a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s0a0l25;	.
+:c1_0c1s0a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l20;	.
+:c1_0c1s0a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l21;	.
+:c1_0c1s0a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l22;	.
+:c1_0c1s0a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l23;	.
+:c1_0c1s0a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l26;	.
+:c1_0c1s0a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l25;	.
+:c1_0c1s0a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s0a0l24;	.
+:c1_0c1s0a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l44;	.
+:c1_0c1s0a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l30;	.
+:c1_0c1s0a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l31;	.
+:c1_0c1s0a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l32;	.
+:c1_0c1s0a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l33;	.
+:c1_0c1s0a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l34;	.
+:c1_0c1s0a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l47;	.
+:c1_0c1s0a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l46;	.
+:c1_0c1s0a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l40;	.
+:c1_0c1s0a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l42 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l43;	.
+:c1_0c1s0a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s0a0l27;	.
+:c1_0c1s0a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s0a0l37;	.
+:c1_0c1s0a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s0a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l50;	.
+:c1_0c1s0a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l51;	.
+:c1_0c1s0a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l52;	.
+:c1_0c1s0a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l53;	.
+:c1_0c1s0a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l54;	.
+:c1_0c1s0a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l55;	.
+:c1_0c1s0a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l56;	.
+:c1_0c1s0a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s0a0l57;	.
+:c1_0c1s0a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s0n0;
+	logset:endPointOf :linkc1_0c1s0a0l50;
+	logset:endPointOf :linkc1_0c1s0a0l51;	.
+:c1_0c1s0a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s0n1;
+	logset:endPointOf :linkc1_0c1s0a0l52;
+	logset:endPointOf :linkc1_0c1s0a0l53;	.
+:c1_0c1s0a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s0n2;
+	logset:endPointOf :linkc1_0c1s0a0l54;
+	logset:endPointOf :linkc1_0c1s0a0l55;	.
+:c1_0c1s0a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s0n3;
+	logset:endPointOf :linkc1_0c1s0a0l56;
+	logset:endPointOf :linkc1_0c1s0a0l57;	.
+:c1_0c1s0n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s0n0;	.
+:c1_0c1s0n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s0n1;	.
+:c1_0c1s0n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s0n2;	.
+:c1_0c1s0n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s0n3;	.
+:c1_0c1s10a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l21;	.
+:c1_0c1s10a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l07 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l22;	.
+:c1_0c1s10a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s10a0l23;	.
+:c1_0c1s10a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l16;	.
+:c1_0c1s10a0l17 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l20;	.
+:c1_0c1s10a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l21;	.
+:c1_0c1s10a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l23;	.
+:c1_0c1s10a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s10a0l22;	.
+:c1_0c1s10a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l24;	.
+:c1_0c1s10a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l25;	.
+:c1_0c1s10a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l26;	.
+:c1_0c1s10a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l24;	.
+:c1_0c1s10a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l40;	.
+:c1_0c1s10a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l30;	.
+:c1_0c1s10a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l43;	.
+:c1_0c1s10a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l32;	.
+:c1_0c1s10a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l30;	.
+:c1_0c1s10a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l31;	.
+:c1_0c1s10a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l40;	.
+:c1_0c1s10a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s10a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s10a0l41;	.
+:c1_0c1s10a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s10a0l33;	.
+:c1_0c1s10a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l33;	.
+:c1_0c1s10a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l43;	.
+:c1_0c1s10a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l41;	.
+:c1_0c1s10a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l41;	.
+:c1_0c1s10a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l50;	.
+:c1_0c1s10a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l51;	.
+:c1_0c1s10a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l52;	.
+:c1_0c1s10a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l53;	.
+:c1_0c1s10a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l54;	.
+:c1_0c1s10a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l55;	.
+:c1_0c1s10a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l56;	.
+:c1_0c1s10a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s10a0l57;	.
+:c1_0c1s10a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s10n0;
+	logset:endPointOf :linkc1_0c1s10a0l50;
+	logset:endPointOf :linkc1_0c1s10a0l51;	.
+:c1_0c1s10a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s10n1;
+	logset:endPointOf :linkc1_0c1s10a0l52;
+	logset:endPointOf :linkc1_0c1s10a0l53;	.
+:c1_0c1s10a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s10n2;
+	logset:endPointOf :linkc1_0c1s10a0l54;
+	logset:endPointOf :linkc1_0c1s10a0l55;	.
+:c1_0c1s10a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s10n3;
+	logset:endPointOf :linkc1_0c1s10a0l56;
+	logset:endPointOf :linkc1_0c1s10a0l57;	.
+:c1_0c1s10n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s10n0;	.
+:c1_0c1s10n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s10n1;	.
+:c1_0c1s10n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s10n2;	.
+:c1_0c1s10n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s10n3;	.
+:c1_0c1s11a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l21;	.
+:c1_0c1s11a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s11a0l07;	.
+:c1_0c1s11a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l22;	.
+:c1_0c1s11a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s11a0l23;	.
+:c1_0c1s11a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l07;	.
+:c1_0c1s11a0l17 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l20;	.
+:c1_0c1s11a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l21;	.
+:c1_0c1s11a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l23;	.
+:c1_0c1s11a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s11a0l22;	.
+:c1_0c1s11a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s11a0l24;	.
+:c1_0c1s11a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l17;	.
+:c1_0c1s11a0l26 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l24;	.
+:c1_0c1s11a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l40;	.
+:c1_0c1s11a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l30;	.
+:c1_0c1s11a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l43;	.
+:c1_0c1s11a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l43;	.
+:c1_0c1s11a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l41;	.
+:c1_0c1s11a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l43;	.
+:c1_0c1s11a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l31;	.
+:c1_0c1s11a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s11a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s11a0l41;	.
+:c1_0c1s11a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s11a0l33;	.
+:c1_0c1s11a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l33;	.
+:c1_0c1s11a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l30;	.
+:c1_0c1s11a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l42;	.
+:c1_0c1s11a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l42;	.
+:c1_0c1s11a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l50;	.
+:c1_0c1s11a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l51;	.
+:c1_0c1s11a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l52;	.
+:c1_0c1s11a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l53;	.
+:c1_0c1s11a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l54;	.
+:c1_0c1s11a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l55;	.
+:c1_0c1s11a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l56;	.
+:c1_0c1s11a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s11a0l57;	.
+:c1_0c1s11a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s11n0;
+	logset:endPointOf :linkc1_0c1s11a0l50;
+	logset:endPointOf :linkc1_0c1s11a0l51;	.
+:c1_0c1s11a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s11n1;
+	logset:endPointOf :linkc1_0c1s11a0l52;
+	logset:endPointOf :linkc1_0c1s11a0l53;	.
+:c1_0c1s11a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s11n2;
+	logset:endPointOf :linkc1_0c1s11a0l54;
+	logset:endPointOf :linkc1_0c1s11a0l55;	.
+:c1_0c1s11a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s11n3;
+	logset:endPointOf :linkc1_0c1s11a0l56;
+	logset:endPointOf :linkc1_0c1s11a0l57;	.
+:c1_0c1s11n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s11n0;	.
+:c1_0c1s11n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s11n1;	.
+:c1_0c1s11n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s11n2;	.
+:c1_0c1s11n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s11n3;	.
+:c1_0c1s12a0l00 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l26;	.
+:c1_0c1s12a0l10 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l11 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l16;	.
+:c1_0c1s12a0l17 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l20;	.
+:c1_0c1s12a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l21;	.
+:c1_0c1s12a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l23;	.
+:c1_0c1s12a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s12a0l22;	.
+:c1_0c1s12a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s12a0l24;	.
+:c1_0c1s12a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l27;	.
+:c1_0c1s12a0l26 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s11a0l24;	.
+:c1_0c1s12a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l40;	.
+:c1_0c1s12a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l30;	.
+:c1_0c1s12a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l43;	.
+:c1_0c1s12a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l32;	.
+:c1_0c1s12a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l31;	.
+:c1_0c1s12a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l42;	.
+:c1_0c1s12a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l31;	.
+:c1_0c1s12a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s12a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s12a0l41;	.
+:c1_0c1s12a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s12a0l33;	.
+:c1_0c1s12a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l33;	.
+:c1_0c1s12a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l30;	.
+:c1_0c1s12a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l32;	.
+:c1_0c1s12a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l40;	.
+:c1_0c1s12a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l50;	.
+:c1_0c1s12a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l51;	.
+:c1_0c1s12a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l52;	.
+:c1_0c1s12a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l53;	.
+:c1_0c1s12a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l54;	.
+:c1_0c1s12a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l55;	.
+:c1_0c1s12a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l56;	.
+:c1_0c1s12a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s12a0l57;	.
+:c1_0c1s12a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s12n0;
+	logset:endPointOf :linkc1_0c1s12a0l50;
+	logset:endPointOf :linkc1_0c1s12a0l51;	.
+:c1_0c1s12a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s12n1;
+	logset:endPointOf :linkc1_0c1s12a0l52;
+	logset:endPointOf :linkc1_0c1s12a0l53;	.
+:c1_0c1s12a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s12n2;
+	logset:endPointOf :linkc1_0c1s12a0l54;
+	logset:endPointOf :linkc1_0c1s12a0l55;	.
+:c1_0c1s12a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s12n3;
+	logset:endPointOf :linkc1_0c1s12a0l56;
+	logset:endPointOf :linkc1_0c1s12a0l57;	.
+:c1_0c1s12n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s12n0;	.
+:c1_0c1s12n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s12n1;	.
+:c1_0c1s12n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s12n2;	.
+:c1_0c1s12n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s12n3;	.
+:c1_0c1s13a0l00 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l16;	.
+:c1_0c1s13a0l10 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l11 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s11a0l07;	.
+:c1_0c1s13a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s10a0l25;	.
+:c1_0c1s13a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l20;	.
+:c1_0c1s13a0l21 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l22 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l23 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l24 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l25 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l25;	.
+:c1_0c1s13a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s12a0l24;	.
+:c1_0c1s13a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l40;	.
+:c1_0c1s13a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l30;	.
+:c1_0c1s13a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l43;	.
+:c1_0c1s13a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l32;	.
+:c1_0c1s13a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l42;	.
+:c1_0c1s13a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l43;	.
+:c1_0c1s13a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l40;	.
+:c1_0c1s13a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s13a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s13a0l41;	.
+:c1_0c1s13a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s13a0l33;	.
+:c1_0c1s13a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l33;	.
+:c1_0c1s13a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l30;	.
+:c1_0c1s13a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l33;	.
+:c1_0c1s13a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l33;	.
+:c1_0c1s13a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l50;	.
+:c1_0c1s13a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l51;	.
+:c1_0c1s13a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l52;	.
+:c1_0c1s13a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l53;	.
+:c1_0c1s13a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l54;	.
+:c1_0c1s13a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l55;	.
+:c1_0c1s13a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l56;	.
+:c1_0c1s13a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s13a0l57;	.
+:c1_0c1s13a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s13n0;
+	logset:endPointOf :linkc1_0c1s13a0l50;
+	logset:endPointOf :linkc1_0c1s13a0l51;	.
+:c1_0c1s13a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s13n1;
+	logset:endPointOf :linkc1_0c1s13a0l52;
+	logset:endPointOf :linkc1_0c1s13a0l53;	.
+:c1_0c1s13a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s13n2;
+	logset:endPointOf :linkc1_0c1s13a0l54;
+	logset:endPointOf :linkc1_0c1s13a0l55;	.
+:c1_0c1s13a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s13n3;
+	logset:endPointOf :linkc1_0c1s13a0l56;
+	logset:endPointOf :linkc1_0c1s13a0l57;	.
+:c1_0c1s13n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s13n0;	.
+:c1_0c1s13n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s13n1;	.
+:c1_0c1s13n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s13n2;	.
+:c1_0c1s13n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s13n3;	.
+:c1_0c1s1a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l00;	.
+:c1_0c1s1a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l24;	.
+:c1_0c1s1a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l10;	.
+:c1_0c1s1a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l11;	.
+:c1_0c1s1a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l26;	.
+:c1_0c1s1a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s1a0l25;	.
+:c1_0c1s1a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l23;	.
+:c1_0c1s1a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l21;	.
+:c1_0c1s1a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l22;	.
+:c1_0c1s1a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l23;	.
+:c1_0c1s1a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l26;	.
+:c1_0c1s1a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l25;	.
+:c1_0c1s1a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s1a0l24;	.
+:c1_0c1s1a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l44;	.
+:c1_0c1s1a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l30;	.
+:c1_0c1s1a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l31;	.
+:c1_0c1s1a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l32;	.
+:c1_0c1s1a0l33 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l34;	.
+:c1_0c1s1a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l47;	.
+:c1_0c1s1a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l46;	.
+:c1_0c1s1a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l41;	.
+:c1_0c1s1a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l42;	.
+:c1_0c1s1a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l43;	.
+:c1_0c1s1a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s1a0l27;	.
+:c1_0c1s1a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s1a0l37;	.
+:c1_0c1s1a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s1a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l50;	.
+:c1_0c1s1a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l51;	.
+:c1_0c1s1a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l52;	.
+:c1_0c1s1a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l53;	.
+:c1_0c1s1a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l54;	.
+:c1_0c1s1a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l55;	.
+:c1_0c1s1a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l56;	.
+:c1_0c1s1a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s1a0l57;	.
+:c1_0c1s1a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s1n0;
+	logset:endPointOf :linkc1_0c1s1a0l50;
+	logset:endPointOf :linkc1_0c1s1a0l51;	.
+:c1_0c1s1a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s1n1;
+	logset:endPointOf :linkc1_0c1s1a0l52;
+	logset:endPointOf :linkc1_0c1s1a0l53;	.
+:c1_0c1s1a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s1n2;
+	logset:endPointOf :linkc1_0c1s1a0l54;
+	logset:endPointOf :linkc1_0c1s1a0l55;	.
+:c1_0c1s1a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s1n3;
+	logset:endPointOf :linkc1_0c1s1a0l56;
+	logset:endPointOf :linkc1_0c1s1a0l57;	.
+:c1_0c1s1n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s1n0;	.
+:c1_0c1s1n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s1n1;	.
+:c1_0c1s1n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s1n2;	.
+:c1_0c1s1n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s1n3;	.
+:c1_0c1s2a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l00;	.
+:c1_0c1s2a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l24;	.
+:c1_0c1s2a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l10;	.
+:c1_0c1s2a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l11;	.
+:c1_0c1s2a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l26;	.
+:c1_0c1s2a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s2a0l25;	.
+:c1_0c1s2a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l23;	.
+:c1_0c1s2a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l10;	.
+:c1_0c1s2a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l22;	.
+:c1_0c1s2a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l23;	.
+:c1_0c1s2a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l26;	.
+:c1_0c1s2a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l25;	.
+:c1_0c1s2a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s2a0l24;	.
+:c1_0c1s2a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l44;	.
+:c1_0c1s2a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l30;	.
+:c1_0c1s2a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l31;	.
+:c1_0c1s2a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l32;	.
+:c1_0c1s2a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l33;	.
+:c1_0c1s2a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l34;	.
+:c1_0c1s2a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l47;	.
+:c1_0c1s2a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l46;	.
+:c1_0c1s2a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l40;	.
+:c1_0c1s2a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l41;	.
+:c1_0c1s2a0l42 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l43 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s2a0l27;	.
+:c1_0c1s2a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s2a0l37;	.
+:c1_0c1s2a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s2a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l50;	.
+:c1_0c1s2a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l51;	.
+:c1_0c1s2a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l52;	.
+:c1_0c1s2a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l53;	.
+:c1_0c1s2a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l54;	.
+:c1_0c1s2a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l55;	.
+:c1_0c1s2a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l56;	.
+:c1_0c1s2a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s2a0l57;	.
+:c1_0c1s2a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s2n0;
+	logset:endPointOf :linkc1_0c1s2a0l50;
+	logset:endPointOf :linkc1_0c1s2a0l51;	.
+:c1_0c1s2a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s2n1;
+	logset:endPointOf :linkc1_0c1s2a0l52;
+	logset:endPointOf :linkc1_0c1s2a0l53;	.
+:c1_0c1s2a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s2n2;
+	logset:endPointOf :linkc1_0c1s2a0l54;
+	logset:endPointOf :linkc1_0c1s2a0l55;	.
+:c1_0c1s2a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s2n3;
+	logset:endPointOf :linkc1_0c1s2a0l56;
+	logset:endPointOf :linkc1_0c1s2a0l57;	.
+:c1_0c1s2n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s2n0;	.
+:c1_0c1s2n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s2n1;	.
+:c1_0c1s2n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s2n2;	.
+:c1_0c1s2n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s2n3;	.
+:c1_0c1s3a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l00;	.
+:c1_0c1s3a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l24;	.
+:c1_0c1s3a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l10;	.
+:c1_0c1s3a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l00;	.
+:c1_0c1s3a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l26;	.
+:c1_0c1s3a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s3a0l25;	.
+:c1_0c1s3a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l23;	.
+:c1_0c1s3a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l21;	.
+:c1_0c1s3a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l21;	.
+:c1_0c1s3a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l23;	.
+:c1_0c1s3a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l26;	.
+:c1_0c1s3a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l25;	.
+:c1_0c1s3a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s3a0l24;	.
+:c1_0c1s3a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l44;	.
+:c1_0c1s3a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l31;	.
+:c1_0c1s3a0l32 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l33;	.
+:c1_0c1s3a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l34;	.
+:c1_0c1s3a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l47;	.
+:c1_0c1s3a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l46;	.
+:c1_0c1s3a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l40;	.
+:c1_0c1s3a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l41;	.
+:c1_0c1s3a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l42;	.
+:c1_0c1s3a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l43;	.
+:c1_0c1s3a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s3a0l27;	.
+:c1_0c1s3a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s3a0l37;	.
+:c1_0c1s3a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s3a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l50;	.
+:c1_0c1s3a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l51;	.
+:c1_0c1s3a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l52;	.
+:c1_0c1s3a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l53;	.
+:c1_0c1s3a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l54;	.
+:c1_0c1s3a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l55;	.
+:c1_0c1s3a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l56;	.
+:c1_0c1s3a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s3a0l57;	.
+:c1_0c1s3a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s3n0;
+	logset:endPointOf :linkc1_0c1s3a0l50;
+	logset:endPointOf :linkc1_0c1s3a0l51;	.
+:c1_0c1s3a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s3n1;
+	logset:endPointOf :linkc1_0c1s3a0l52;
+	logset:endPointOf :linkc1_0c1s3a0l53;	.
+:c1_0c1s3a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s3n2;
+	logset:endPointOf :linkc1_0c1s3a0l54;
+	logset:endPointOf :linkc1_0c1s3a0l55;	.
+:c1_0c1s3a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s3n3;
+	logset:endPointOf :linkc1_0c1s3a0l56;
+	logset:endPointOf :linkc1_0c1s3a0l57;	.
+:c1_0c1s3n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s3n0;	.
+:c1_0c1s3n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s3n1;	.
+:c1_0c1s3n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s3n2;	.
+:c1_0c1s3n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s3n3;	.
+:c1_0c1s4a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l21;	.
+:c1_0c1s4a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l24;	.
+:c1_0c1s4a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l10;	.
+:c1_0c1s4a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l11;	.
+:c1_0c1s4a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l26;	.
+:c1_0c1s4a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s4a0l25;	.
+:c1_0c1s4a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l23;	.
+:c1_0c1s4a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l21;	.
+:c1_0c1s4a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l20;	.
+:c1_0c1s4a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l23;	.
+:c1_0c1s4a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l26;	.
+:c1_0c1s4a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l25;	.
+:c1_0c1s4a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s4a0l24;	.
+:c1_0c1s4a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l44;	.
+:c1_0c1s4a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l30;	.
+:c1_0c1s4a0l31 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l32;	.
+:c1_0c1s4a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l33;	.
+:c1_0c1s4a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l34;	.
+:c1_0c1s4a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l47;	.
+:c1_0c1s4a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l46;	.
+:c1_0c1s4a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l40;	.
+:c1_0c1s4a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l41;	.
+:c1_0c1s4a0l42 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l43;	.
+:c1_0c1s4a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s4a0l27;	.
+:c1_0c1s4a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s4a0l37;	.
+:c1_0c1s4a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s4a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l50;	.
+:c1_0c1s4a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l51;	.
+:c1_0c1s4a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l52;	.
+:c1_0c1s4a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l53;	.
+:c1_0c1s4a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l54;	.
+:c1_0c1s4a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l55;	.
+:c1_0c1s4a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l56;	.
+:c1_0c1s4a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s4a0l57;	.
+:c1_0c1s4a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s4n0;
+	logset:endPointOf :linkc1_0c1s4a0l50;
+	logset:endPointOf :linkc1_0c1s4a0l51;	.
+:c1_0c1s4a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s4n1;
+	logset:endPointOf :linkc1_0c1s4a0l52;
+	logset:endPointOf :linkc1_0c1s4a0l53;	.
+:c1_0c1s4a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s4n2;
+	logset:endPointOf :linkc1_0c1s4a0l54;
+	logset:endPointOf :linkc1_0c1s4a0l55;	.
+:c1_0c1s4a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s4n3;
+	logset:endPointOf :linkc1_0c1s4a0l56;
+	logset:endPointOf :linkc1_0c1s4a0l57;	.
+:c1_0c1s4n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s4n0;	.
+:c1_0c1s4n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s4n1;	.
+:c1_0c1s4n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s4n2;	.
+:c1_0c1s4n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s4n3;	.
+:c1_0c1s5a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l11;	.
+:c1_0c1s5a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l24;	.
+:c1_0c1s5a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l22;	.
+:c1_0c1s5a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l00;	.
+:c1_0c1s5a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l26;	.
+:c1_0c1s5a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s5a0l25;	.
+:c1_0c1s5a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l23;	.
+:c1_0c1s5a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l22;	.
+:c1_0c1s5a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l22;	.
+:c1_0c1s5a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l23;	.
+:c1_0c1s5a0l24 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l25 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l26 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l44;	.
+:c1_0c1s5a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l31 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l32;	.
+:c1_0c1s5a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l33;	.
+:c1_0c1s5a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l34;	.
+:c1_0c1s5a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l47;	.
+:c1_0c1s5a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l46;	.
+:c1_0c1s5a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l40;	.
+:c1_0c1s5a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l41;	.
+:c1_0c1s5a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l42;	.
+:c1_0c1s5a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l43;	.
+:c1_0c1s5a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s5a0l27;	.
+:c1_0c1s5a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s5a0l37;	.
+:c1_0c1s5a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s5a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l50;	.
+:c1_0c1s5a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l51;	.
+:c1_0c1s5a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l52;	.
+:c1_0c1s5a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l53;	.
+:c1_0c1s5a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l54;	.
+:c1_0c1s5a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l55;	.
+:c1_0c1s5a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l56;	.
+:c1_0c1s5a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s5a0l57;	.
+:c1_0c1s5a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s5n0;
+	logset:endPointOf :linkc1_0c1s5a0l50;
+	logset:endPointOf :linkc1_0c1s5a0l51;	.
+:c1_0c1s5a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s5n1;
+	logset:endPointOf :linkc1_0c1s5a0l52;
+	logset:endPointOf :linkc1_0c1s5a0l53;	.
+:c1_0c1s5a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s5n2;
+	logset:endPointOf :linkc1_0c1s5a0l54;
+	logset:endPointOf :linkc1_0c1s5a0l55;	.
+:c1_0c1s5a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s5n3;
+	logset:endPointOf :linkc1_0c1s5a0l56;
+	logset:endPointOf :linkc1_0c1s5a0l57;	.
+:c1_0c1s5n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s5n0;	.
+:c1_0c1s5n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s5n1;	.
+:c1_0c1s5n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s5n2;	.
+:c1_0c1s5n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s5n3;	.
+:c1_0c1s6a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l10;	.
+:c1_0c1s6a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l24;	.
+:c1_0c1s6a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l00;	.
+:c1_0c1s6a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l00;	.
+:c1_0c1s6a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l26;	.
+:c1_0c1s6a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s6a0l25;	.
+:c1_0c1s6a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l23;	.
+:c1_0c1s6a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l10;	.
+:c1_0c1s6a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l10;	.
+:c1_0c1s6a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l23;	.
+:c1_0c1s6a0l24 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l25 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l26 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l44;	.
+:c1_0c1s6a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l30;	.
+:c1_0c1s6a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l31;	.
+:c1_0c1s6a0l32 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l33;	.
+:c1_0c1s6a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l34;	.
+:c1_0c1s6a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l47;	.
+:c1_0c1s6a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l46;	.
+:c1_0c1s6a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l40;	.
+:c1_0c1s6a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l41;	.
+:c1_0c1s6a0l42 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l43;	.
+:c1_0c1s6a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s6a0l27;	.
+:c1_0c1s6a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s6a0l37;	.
+:c1_0c1s6a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s6a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l50;	.
+:c1_0c1s6a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l51;	.
+:c1_0c1s6a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l52;	.
+:c1_0c1s6a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l53;	.
+:c1_0c1s6a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l54;	.
+:c1_0c1s6a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l55;	.
+:c1_0c1s6a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l56;	.
+:c1_0c1s6a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s6a0l57;	.
+:c1_0c1s6a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s6n0;
+	logset:endPointOf :linkc1_0c1s6a0l50;
+	logset:endPointOf :linkc1_0c1s6a0l51;	.
+:c1_0c1s6a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s6n1;
+	logset:endPointOf :linkc1_0c1s6a0l52;
+	logset:endPointOf :linkc1_0c1s6a0l53;	.
+:c1_0c1s6a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s6n2;
+	logset:endPointOf :linkc1_0c1s6a0l54;
+	logset:endPointOf :linkc1_0c1s6a0l55;	.
+:c1_0c1s6a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s6n3;
+	logset:endPointOf :linkc1_0c1s6a0l56;
+	logset:endPointOf :linkc1_0c1s6a0l57;	.
+:c1_0c1s6n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s6n0;	.
+:c1_0c1s6n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s6n1;	.
+:c1_0c1s6n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s6n2;	.
+:c1_0c1s6n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s6n3;	.
+:c1_0c1s7a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l11;	.
+:c1_0c1s7a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l24;	.
+:c1_0c1s7a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l21;	.
+:c1_0c1s7a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l22;	.
+:c1_0c1s7a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l26;	.
+:c1_0c1s7a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s7a0l25;	.
+:c1_0c1s7a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l23;	.
+:c1_0c1s7a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l10;	.
+:c1_0c1s7a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l21;	.
+:c1_0c1s7a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l22;	.
+:c1_0c1s7a0l24 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l25 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l26 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l44;	.
+:c1_0c1s7a0l30 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l30;	.
+:c1_0c1s7a0l31 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l32;	.
+:c1_0c1s7a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l33;	.
+:c1_0c1s7a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l34;	.
+:c1_0c1s7a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l47;	.
+:c1_0c1s7a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l46;	.
+:c1_0c1s7a0l37 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l40 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l40;	.
+:c1_0c1s7a0l41 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l41;	.
+:c1_0c1s7a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l42;	.
+:c1_0c1s7a0l43 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s7a0l27;	.
+:c1_0c1s7a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s7a0l37;	.
+:c1_0c1s7a0l46 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l47 a craydict:NetworkTile ;	.
+:c1_0c1s7a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l50;	.
+:c1_0c1s7a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l51;	.
+:c1_0c1s7a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l52;	.
+:c1_0c1s7a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l53;	.
+:c1_0c1s7a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l54;	.
+:c1_0c1s7a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l55;	.
+:c1_0c1s7a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l56;	.
+:c1_0c1s7a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s7a0l57;	.
+:c1_0c1s7a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s7n0;
+	logset:endPointOf :linkc1_0c1s7a0l50;
+	logset:endPointOf :linkc1_0c1s7a0l51;	.
+:c1_0c1s7a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s7n1;
+	logset:endPointOf :linkc1_0c1s7a0l52;
+	logset:endPointOf :linkc1_0c1s7a0l53;	.
+:c1_0c1s7a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s7n2;
+	logset:endPointOf :linkc1_0c1s7a0l54;
+	logset:endPointOf :linkc1_0c1s7a0l55;	.
+:c1_0c1s7a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s7n3;
+	logset:endPointOf :linkc1_0c1s7a0l56;
+	logset:endPointOf :linkc1_0c1s7a0l57;	.
+:c1_0c1s7n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s7n0;	.
+:c1_0c1s7n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s7n1;	.
+:c1_0c1s7n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s7n2;	.
+:c1_0c1s7n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s7n3;	.
+:c1_0c1s8a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l21;	.
+:c1_0c1s8a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l07 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l22;	.
+:c1_0c1s8a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s8a0l23;	.
+:c1_0c1s8a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l16 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l17 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l17;	.
+:c1_0c1s8a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l20;	.
+:c1_0c1s8a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l21;	.
+:c1_0c1s8a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l23;	.
+:c1_0c1s8a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s8a0l22;	.
+:c1_0c1s8a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l24;	.
+:c1_0c1s8a0l25 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l25;	.
+:c1_0c1s8a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l26;	.
+:c1_0c1s8a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l27;	.
+:c1_0c1s8a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l40;	.
+:c1_0c1s8a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l30;	.
+:c1_0c1s8a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l43;	.
+:c1_0c1s8a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l43;	.
+:c1_0c1s8a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l32;	.
+:c1_0c1s8a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l40;	.
+:c1_0c1s8a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l41;	.
+:c1_0c1s8a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s8a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s8a0l41;	.
+:c1_0c1s8a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s8a0l33;	.
+:c1_0c1s8a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l41;	.
+:c1_0c1s8a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l30;	.
+:c1_0c1s8a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l41;	.
+:c1_0c1s8a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l40;	.
+:c1_0c1s8a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l50;	.
+:c1_0c1s8a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l51;	.
+:c1_0c1s8a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l52;	.
+:c1_0c1s8a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l53;	.
+:c1_0c1s8a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l54;	.
+:c1_0c1s8a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l55;	.
+:c1_0c1s8a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l56;	.
+:c1_0c1s8a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s8a0l57;	.
+:c1_0c1s8a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s8n0;
+	logset:endPointOf :linkc1_0c1s8a0l50;
+	logset:endPointOf :linkc1_0c1s8a0l51;	.
+:c1_0c1s8a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s8n1;
+	logset:endPointOf :linkc1_0c1s8a0l52;
+	logset:endPointOf :linkc1_0c1s8a0l53;	.
+:c1_0c1s8a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s8n2;
+	logset:endPointOf :linkc1_0c1s8a0l54;
+	logset:endPointOf :linkc1_0c1s8a0l55;	.
+:c1_0c1s8a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s8n3;
+	logset:endPointOf :linkc1_0c1s8a0l56;
+	logset:endPointOf :linkc1_0c1s8a0l57;	.
+:c1_0c1s8n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s8n0;	.
+:c1_0c1s8n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s8n1;	.
+:c1_0c1s8n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s8n2;	.
+:c1_0c1s8n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s8n3;	.
+:c1_0c1s9a0l00 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l21;	.
+:c1_0c1s9a0l01 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l02 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l03 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l04 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l05 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l06 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l07 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l07;	.
+:c1_0c1s9a0l10 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l22;	.
+:c1_0c1s9a0l11 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c0s9a0l23;	.
+:c1_0c1s9a0l12 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l13 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l14 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l15 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l16 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l16;	.
+:c1_0c1s9a0l17 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l20 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l20;	.
+:c1_0c1s9a0l21 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l21;	.
+:c1_0c1s9a0l22 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l23;	.
+:c1_0c1s9a0l23 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c2s9a0l22;	.
+:c1_0c1s9a0l24 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l24;	.
+:c1_0c1s9a0l25 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l26 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s9a0l26;	.
+:c1_0c1s9a0l27 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s8a0l24;	.
+:c1_0c1s9a0l30 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l31 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l40;	.
+:c1_0c1s9a0l32 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l30;	.
+:c1_0c1s9a0l33 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l43;	.
+:c1_0c1s9a0l34 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s6a0l43;	.
+:c1_0c1s9a0l35 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s5a0l32;	.
+:c1_0c1s9a0l36 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s0a0l33;	.
+:c1_0c1s9a0l37 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s1a0l31;	.
+:c1_0c1s9a0l40 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l41 a craydict:NetworkTile ;	.
+:c1_0c1s9a0l42 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c0s9a0l41;	.
+:c1_0c1s9a0l43 a craydict:NetworkTile ;
+	logset:endPointOf :linkc0_0c1s9a0l33;	.
+:c1_0c1s9a0l44 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s2a0l40;	.
+:c1_0c1s9a0l45 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s4a0l30;	.
+:c1_0c1s9a0l46 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s3a0l41;	.
+:c1_0c1s9a0l47 a craydict:NetworkTile ;
+	logset:endPointOf :linkc1_0c1s7a0l40;	.
+:c1_0c1s9a0l50 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l50;	.
+:c1_0c1s9a0l51 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l51;	.
+:c1_0c1s9a0l52 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l52;	.
+:c1_0c1s9a0l53 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l53;	.
+:c1_0c1s9a0l54 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l54;	.
+:c1_0c1s9a0l55 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l55;	.
+:c1_0c1s9a0l56 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l56;	.
+:c1_0c1s9a0l57 a craydict:PTile ;
+	logset:endPointOf :linkc1_0c1s9a0l57;	.
+:c1_0c1s9a0n0 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s9n0;
+	logset:endPointOf :linkc1_0c1s9a0l50;
+	logset:endPointOf :linkc1_0c1s9a0l51;	.
+:c1_0c1s9a0n1 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s9n1;
+	logset:endPointOf :linkc1_0c1s9a0l52;
+	logset:endPointOf :linkc1_0c1s9a0l53;	.
+:c1_0c1s9a0n2 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s9n2;
+	logset:endPointOf :linkc1_0c1s9a0l54;
+	logset:endPointOf :linkc1_0c1s9a0l55;	.
+:c1_0c1s9a0n3 a ddict:NIC ;
+	logset:endPointOf :pciec1_0c1s9n3;
+	logset:endPointOf :linkc1_0c1s9a0l56;
+	logset:endPointOf :linkc1_0c1s9a0l57;	.
+:c1_0c1s9n0 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s9n0;	.
+:c1_0c1s9n1 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s9n1;	.
+:c1_0c1s9n2 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s9n2;	.
+:c1_0c1s9n3 a ddict:ComputeNode ;
+	logset:endPointOf :pciec1_0c1s9n3;	.
+
+:pciec0_0c0s0n0 a ddict:PCIeLink .
+:pciec0_0c0s0n1 a ddict:PCIeLink .
+:pciec0_0c0s0n2 a ddict:PCIeLink .
+:pciec0_0c0s0n3 a ddict:PCIeLink .
+:pciec0_0c0s10n0 a ddict:PCIeLink .
+:pciec0_0c0s10n1 a ddict:PCIeLink .
+:pciec0_0c0s10n2 a ddict:PCIeLink .
+:pciec0_0c0s10n3 a ddict:PCIeLink .
+:pciec0_0c0s11n0 a ddict:PCIeLink .
+:pciec0_0c0s11n1 a ddict:PCIeLink .
+:pciec0_0c0s11n2 a ddict:PCIeLink .
+:pciec0_0c0s11n3 a ddict:PCIeLink .
+:pciec0_0c0s1n0 a ddict:PCIeLink .
+:pciec0_0c0s1n1 a ddict:PCIeLink .
+:pciec0_0c0s1n2 a ddict:PCIeLink .
+:pciec0_0c0s1n3 a ddict:PCIeLink .
+:pciec0_0c0s2n0 a ddict:PCIeLink .
+:pciec0_0c0s2n1 a ddict:PCIeLink .
+:pciec0_0c0s2n2 a ddict:PCIeLink .
+:pciec0_0c0s2n3 a ddict:PCIeLink .
+:pciec0_0c0s3n0 a ddict:PCIeLink .
+:pciec0_0c0s3n1 a ddict:PCIeLink .
+:pciec0_0c0s3n2 a ddict:PCIeLink .
+:pciec0_0c0s3n3 a ddict:PCIeLink .
+:pciec0_0c0s4n0 a ddict:PCIeLink .
+:pciec0_0c0s4n1 a ddict:PCIeLink .
+:pciec0_0c0s4n2 a ddict:PCIeLink .
+:pciec0_0c0s4n3 a ddict:PCIeLink .
+:pciec0_0c0s5n0 a ddict:PCIeLink .
+:pciec0_0c0s5n1 a ddict:PCIeLink .
+:pciec0_0c0s5n2 a ddict:PCIeLink .
+:pciec0_0c0s5n3 a ddict:PCIeLink .
+:pciec0_0c0s6n0 a ddict:PCIeLink .
+:pciec0_0c0s6n1 a ddict:PCIeLink .
+:pciec0_0c0s6n2 a ddict:PCIeLink .
+:pciec0_0c0s6n3 a ddict:PCIeLink .
+:pciec0_0c0s7n0 a ddict:PCIeLink .
+:pciec0_0c0s7n1 a ddict:PCIeLink .
+:pciec0_0c0s7n2 a ddict:PCIeLink .
+:pciec0_0c0s7n3 a ddict:PCIeLink .
+:pciec0_0c0s8n0 a ddict:PCIeLink .
+:pciec0_0c0s8n1 a ddict:PCIeLink .
+:pciec0_0c0s8n2 a ddict:PCIeLink .
+:pciec0_0c0s8n3 a ddict:PCIeLink .
+:pciec0_0c0s9n0 a ddict:PCIeLink .
+:pciec0_0c0s9n1 a ddict:PCIeLink .
+:pciec0_0c0s9n2 a ddict:PCIeLink .
+:pciec0_0c0s9n3 a ddict:PCIeLink .
+:pciec0_0c1s0n0 a ddict:PCIeLink .
+:pciec0_0c1s0n1 a ddict:PCIeLink .
+:pciec0_0c1s0n2 a ddict:PCIeLink .
+:pciec0_0c1s0n3 a ddict:PCIeLink .
+:pciec0_0c1s10n0 a ddict:PCIeLink .
+:pciec0_0c1s10n1 a ddict:PCIeLink .
+:pciec0_0c1s10n2 a ddict:PCIeLink .
+:pciec0_0c1s10n3 a ddict:PCIeLink .
+:pciec0_0c1s11n0 a ddict:PCIeLink .
+:pciec0_0c1s11n1 a ddict:PCIeLink .
+:pciec0_0c1s11n2 a ddict:PCIeLink .
+:pciec0_0c1s11n3 a ddict:PCIeLink .
+:pciec0_0c1s12n0 a ddict:PCIeLink .
+:pciec0_0c1s12n1 a ddict:PCIeLink .
+:pciec0_0c1s12n2 a ddict:PCIeLink .
+:pciec0_0c1s12n3 a ddict:PCIeLink .
+:pciec0_0c1s13n0 a ddict:PCIeLink .
+:pciec0_0c1s13n1 a ddict:PCIeLink .
+:pciec0_0c1s13n2 a ddict:PCIeLink .
+:pciec0_0c1s13n3 a ddict:PCIeLink .
+:pciec0_0c1s14n0 a ddict:PCIeLink .
+:pciec0_0c1s14n1 a ddict:PCIeLink .
+:pciec0_0c1s14n2 a ddict:PCIeLink .
+:pciec0_0c1s14n3 a ddict:PCIeLink .
+:pciec0_0c1s15n0 a ddict:PCIeLink .
+:pciec0_0c1s15n1 a ddict:PCIeLink .
+:pciec0_0c1s15n2 a ddict:PCIeLink .
+:pciec0_0c1s15n3 a ddict:PCIeLink .
+:pciec0_0c1s1n0 a ddict:PCIeLink .
+:pciec0_0c1s1n1 a ddict:PCIeLink .
+:pciec0_0c1s1n2 a ddict:PCIeLink .
+:pciec0_0c1s1n3 a ddict:PCIeLink .
+:pciec0_0c1s2n0 a ddict:PCIeLink .
+:pciec0_0c1s2n1 a ddict:PCIeLink .
+:pciec0_0c1s2n2 a ddict:PCIeLink .
+:pciec0_0c1s2n3 a ddict:PCIeLink .
+:pciec0_0c1s3n0 a ddict:PCIeLink .
+:pciec0_0c1s3n1 a ddict:PCIeLink .
+:pciec0_0c1s3n2 a ddict:PCIeLink .
+:pciec0_0c1s3n3 a ddict:PCIeLink .
+:pciec0_0c1s4n0 a ddict:PCIeLink .
+:pciec0_0c1s4n1 a ddict:PCIeLink .
+:pciec0_0c1s4n2 a ddict:PCIeLink .
+:pciec0_0c1s4n3 a ddict:PCIeLink .
+:pciec0_0c1s5n0 a ddict:PCIeLink .
+:pciec0_0c1s5n1 a ddict:PCIeLink .
+:pciec0_0c1s5n2 a ddict:PCIeLink .
+:pciec0_0c1s5n3 a ddict:PCIeLink .
+:pciec0_0c1s6n0 a ddict:PCIeLink .
+:pciec0_0c1s6n1 a ddict:PCIeLink .
+:pciec0_0c1s6n2 a ddict:PCIeLink .
+:pciec0_0c1s6n3 a ddict:PCIeLink .
+:pciec0_0c1s7n0 a ddict:PCIeLink .
+:pciec0_0c1s7n1 a ddict:PCIeLink .
+:pciec0_0c1s7n2 a ddict:PCIeLink .
+:pciec0_0c1s7n3 a ddict:PCIeLink .
+:pciec0_0c1s8n0 a ddict:PCIeLink .
+:pciec0_0c1s8n1 a ddict:PCIeLink .
+:pciec0_0c1s8n2 a ddict:PCIeLink .
+:pciec0_0c1s8n3 a ddict:PCIeLink .
+:pciec0_0c1s9n0 a ddict:PCIeLink .
+:pciec0_0c1s9n1 a ddict:PCIeLink .
+:pciec0_0c1s9n2 a ddict:PCIeLink .
+:pciec0_0c1s9n3 a ddict:PCIeLink .
+:pciec0_0c2s0n0 a ddict:PCIeLink .
+:pciec0_0c2s0n1 a ddict:PCIeLink .
+:pciec0_0c2s0n2 a ddict:PCIeLink .
+:pciec0_0c2s0n3 a ddict:PCIeLink .
+:pciec0_0c2s10n0 a ddict:PCIeLink .
+:pciec0_0c2s10n1 a ddict:PCIeLink .
+:pciec0_0c2s10n2 a ddict:PCIeLink .
+:pciec0_0c2s10n3 a ddict:PCIeLink .
+:pciec0_0c2s11n0 a ddict:PCIeLink .
+:pciec0_0c2s11n1 a ddict:PCIeLink .
+:pciec0_0c2s11n2 a ddict:PCIeLink .
+:pciec0_0c2s11n3 a ddict:PCIeLink .
+:pciec0_0c2s12n0 a ddict:PCIeLink .
+:pciec0_0c2s12n1 a ddict:PCIeLink .
+:pciec0_0c2s12n2 a ddict:PCIeLink .
+:pciec0_0c2s12n3 a ddict:PCIeLink .
+:pciec0_0c2s1n0 a ddict:PCIeLink .
+:pciec0_0c2s1n1 a ddict:PCIeLink .
+:pciec0_0c2s1n2 a ddict:PCIeLink .
+:pciec0_0c2s1n3 a ddict:PCIeLink .
+:pciec0_0c2s2n0 a ddict:PCIeLink .
+:pciec0_0c2s2n1 a ddict:PCIeLink .
+:pciec0_0c2s2n2 a ddict:PCIeLink .
+:pciec0_0c2s2n3 a ddict:PCIeLink .
+:pciec0_0c2s3n0 a ddict:PCIeLink .
+:pciec0_0c2s3n1 a ddict:PCIeLink .
+:pciec0_0c2s3n2 a ddict:PCIeLink .
+:pciec0_0c2s3n3 a ddict:PCIeLink .
+:pciec0_0c2s4n0 a ddict:PCIeLink .
+:pciec0_0c2s4n1 a ddict:PCIeLink .
+:pciec0_0c2s4n2 a ddict:PCIeLink .
+:pciec0_0c2s4n3 a ddict:PCIeLink .
+:pciec0_0c2s8n0 a ddict:PCIeLink .
+:pciec0_0c2s8n1 a ddict:PCIeLink .
+:pciec0_0c2s8n2 a ddict:PCIeLink .
+:pciec0_0c2s8n3 a ddict:PCIeLink .
+:pciec0_0c2s9n0 a ddict:PCIeLink .
+:pciec0_0c2s9n1 a ddict:PCIeLink .
+:pciec0_0c2s9n2 a ddict:PCIeLink .
+:pciec0_0c2s9n3 a ddict:PCIeLink .
+:pciec1_0c0s0n0 a ddict:PCIeLink .
+:pciec1_0c0s0n1 a ddict:PCIeLink .
+:pciec1_0c0s0n2 a ddict:PCIeLink .
+:pciec1_0c0s0n3 a ddict:PCIeLink .
+:pciec1_0c0s10n0 a ddict:PCIeLink .
+:pciec1_0c0s10n1 a ddict:PCIeLink .
+:pciec1_0c0s10n2 a ddict:PCIeLink .
+:pciec1_0c0s10n3 a ddict:PCIeLink .
+:pciec1_0c0s11n0 a ddict:PCIeLink .
+:pciec1_0c0s11n1 a ddict:PCIeLink .
+:pciec1_0c0s11n2 a ddict:PCIeLink .
+:pciec1_0c0s11n3 a ddict:PCIeLink .
+:pciec1_0c0s12n0 a ddict:PCIeLink .
+:pciec1_0c0s12n1 a ddict:PCIeLink .
+:pciec1_0c0s12n2 a ddict:PCIeLink .
+:pciec1_0c0s12n3 a ddict:PCIeLink .
+:pciec1_0c0s13n0 a ddict:PCIeLink .
+:pciec1_0c0s13n1 a ddict:PCIeLink .
+:pciec1_0c0s13n2 a ddict:PCIeLink .
+:pciec1_0c0s13n3 a ddict:PCIeLink .
+:pciec1_0c0s14n0 a ddict:PCIeLink .
+:pciec1_0c0s14n1 a ddict:PCIeLink .
+:pciec1_0c0s14n2 a ddict:PCIeLink .
+:pciec1_0c0s14n3 a ddict:PCIeLink .
+:pciec1_0c0s15n0 a ddict:PCIeLink .
+:pciec1_0c0s15n1 a ddict:PCIeLink .
+:pciec1_0c0s15n2 a ddict:PCIeLink .
+:pciec1_0c0s15n3 a ddict:PCIeLink .
+:pciec1_0c0s1n0 a ddict:PCIeLink .
+:pciec1_0c0s1n1 a ddict:PCIeLink .
+:pciec1_0c0s1n2 a ddict:PCIeLink .
+:pciec1_0c0s1n3 a ddict:PCIeLink .
+:pciec1_0c0s2n0 a ddict:PCIeLink .
+:pciec1_0c0s2n1 a ddict:PCIeLink .
+:pciec1_0c0s2n2 a ddict:PCIeLink .
+:pciec1_0c0s2n3 a ddict:PCIeLink .
+:pciec1_0c0s3n0 a ddict:PCIeLink .
+:pciec1_0c0s3n1 a ddict:PCIeLink .
+:pciec1_0c0s3n2 a ddict:PCIeLink .
+:pciec1_0c0s3n3 a ddict:PCIeLink .
+:pciec1_0c0s4n0 a ddict:PCIeLink .
+:pciec1_0c0s4n1 a ddict:PCIeLink .
+:pciec1_0c0s4n2 a ddict:PCIeLink .
+:pciec1_0c0s4n3 a ddict:PCIeLink .
+:pciec1_0c0s5n0 a ddict:PCIeLink .
+:pciec1_0c0s5n1 a ddict:PCIeLink .
+:pciec1_0c0s5n2 a ddict:PCIeLink .
+:pciec1_0c0s5n3 a ddict:PCIeLink .
+:pciec1_0c0s6n0 a ddict:PCIeLink .
+:pciec1_0c0s6n1 a ddict:PCIeLink .
+:pciec1_0c0s6n2 a ddict:PCIeLink .
+:pciec1_0c0s6n3 a ddict:PCIeLink .
+:pciec1_0c0s7n0 a ddict:PCIeLink .
+:pciec1_0c0s7n1 a ddict:PCIeLink .
+:pciec1_0c0s7n2 a ddict:PCIeLink .
+:pciec1_0c0s7n3 a ddict:PCIeLink .
+:pciec1_0c0s8n0 a ddict:PCIeLink .
+:pciec1_0c0s8n1 a ddict:PCIeLink .
+:pciec1_0c0s8n2 a ddict:PCIeLink .
+:pciec1_0c0s8n3 a ddict:PCIeLink .
+:pciec1_0c0s9n0 a ddict:PCIeLink .
+:pciec1_0c0s9n1 a ddict:PCIeLink .
+:pciec1_0c0s9n2 a ddict:PCIeLink .
+:pciec1_0c0s9n3 a ddict:PCIeLink .
+:pciec1_0c1s0n0 a ddict:PCIeLink .
+:pciec1_0c1s0n1 a ddict:PCIeLink .
+:pciec1_0c1s0n2 a ddict:PCIeLink .
+:pciec1_0c1s0n3 a ddict:PCIeLink .
+:pciec1_0c1s10n0 a ddict:PCIeLink .
+:pciec1_0c1s10n1 a ddict:PCIeLink .
+:pciec1_0c1s10n2 a ddict:PCIeLink .
+:pciec1_0c1s10n3 a ddict:PCIeLink .
+:pciec1_0c1s11n0 a ddict:PCIeLink .
+:pciec1_0c1s11n1 a ddict:PCIeLink .
+:pciec1_0c1s11n2 a ddict:PCIeLink .
+:pciec1_0c1s11n3 a ddict:PCIeLink .
+:pciec1_0c1s12n0 a ddict:PCIeLink .
+:pciec1_0c1s12n1 a ddict:PCIeLink .
+:pciec1_0c1s12n2 a ddict:PCIeLink .
+:pciec1_0c1s12n3 a ddict:PCIeLink .
+:pciec1_0c1s13n0 a ddict:PCIeLink .
+:pciec1_0c1s13n1 a ddict:PCIeLink .
+:pciec1_0c1s13n2 a ddict:PCIeLink .
+:pciec1_0c1s13n3 a ddict:PCIeLink .
+:pciec1_0c1s1n0 a ddict:PCIeLink .
+:pciec1_0c1s1n1 a ddict:PCIeLink .
+:pciec1_0c1s1n2 a ddict:PCIeLink .
+:pciec1_0c1s1n3 a ddict:PCIeLink .
+:pciec1_0c1s2n0 a ddict:PCIeLink .
+:pciec1_0c1s2n1 a ddict:PCIeLink .
+:pciec1_0c1s2n2 a ddict:PCIeLink .
+:pciec1_0c1s2n3 a ddict:PCIeLink .
+:pciec1_0c1s3n0 a ddict:PCIeLink .
+:pciec1_0c1s3n1 a ddict:PCIeLink .
+:pciec1_0c1s3n2 a ddict:PCIeLink .
+:pciec1_0c1s3n3 a ddict:PCIeLink .
+:pciec1_0c1s4n0 a ddict:PCIeLink .
+:pciec1_0c1s4n1 a ddict:PCIeLink .
+:pciec1_0c1s4n2 a ddict:PCIeLink .
+:pciec1_0c1s4n3 a ddict:PCIeLink .
+:pciec1_0c1s5n0 a ddict:PCIeLink .
+:pciec1_0c1s5n1 a ddict:PCIeLink .
+:pciec1_0c1s5n2 a ddict:PCIeLink .
+:pciec1_0c1s5n3 a ddict:PCIeLink .
+:pciec1_0c1s6n0 a ddict:PCIeLink .
+:pciec1_0c1s6n1 a ddict:PCIeLink .
+:pciec1_0c1s6n2 a ddict:PCIeLink .
+:pciec1_0c1s6n3 a ddict:PCIeLink .
+:pciec1_0c1s7n0 a ddict:PCIeLink .
+:pciec1_0c1s7n1 a ddict:PCIeLink .
+:pciec1_0c1s7n2 a ddict:PCIeLink .
+:pciec1_0c1s7n3 a ddict:PCIeLink .
+:pciec1_0c1s8n0 a ddict:PCIeLink .
+:pciec1_0c1s8n1 a ddict:PCIeLink .
+:pciec1_0c1s8n2 a ddict:PCIeLink .
+:pciec1_0c1s8n3 a ddict:PCIeLink .
+:pciec1_0c1s9n0 a ddict:PCIeLink .
+:pciec1_0c1s9n1 a ddict:PCIeLink .
+:pciec1_0c1s9n2 a ddict:PCIeLink .
+:pciec1_0c1s9n3 a ddict:PCIeLink .
+


### PR DESCRIPTION
As per previous meeting whiteboard, now have NetworkTiles and Ptiles instead of AriesRouterTiles (unused). Also some changes in the link naming convention. Aries only; Gemini not done. Should we have bi-directional links as one link (currently) or two?